### PR TITLE
#17 공통컴포넌트 modal

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,7 @@
     "react/jsx-props-no-spreading": "off",
     "react/jsx-no-useless-fragment": "off",
     "react/button-has-type": "off",
-    "react/require-default-prop": "off",
+    "react/require-default-props": "off",
     "prettier/prettier": "error" // 써보고 쓸데없는 오류가 발생할 경우 직접 설정
   }
 }

--- a/public/icons/ic_close.svg
+++ b/public/icons/ic_close.svg
@@ -1,4 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M18 6L6 18" stroke="#64748B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M6 6L18 18" stroke="#64748B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/public/icons/ic_close.svg
+++ b/public/icons/ic_close.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 6L6 18" stroke="#64748B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 6L18 18" stroke="#64748B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/(component)/modal/page.tsx
+++ b/src/app/(component)/modal/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import Modal from '@/app/components/common/modal/Modal';
+import useModal from '@/app/hooks/useModal';
+
+function ModalExample() {
+  const { isOpen, openModal, closeModal } = useModal();
+
+  const handleClose = () => {
+    /* 이벤트 핸들러 등록 */
+    closeModal();
+  };
+
+  const handleSendLink = () => {
+    /* 이벤트 핸들러 등록 */
+    closeModal();
+  };
+
+  return (
+    <div>
+      <button
+        className="h-8 w-20 bg-white text-lg font-medium text-black"
+        onClick={openModal}
+      >
+        모달 열기
+      </button>
+      {isOpen && (
+        <Modal closeModal={handleClose}>
+          {/**
+           * Modal 컨텐츠 영역
+           * 피그마 예시를 보여주기 위해 디자인에 맞춰 임시로 width: 280px 적용
+           * 작업하실 때 width나 padding으로 조절
+           */}
+          <div className="w-[280px]">
+            <div className="mb-2 text-center text-lg font-medium">
+              비밀번호 재설정
+            </div>
+            <div className="mb-4 text-center text-md text-text-secondary">
+              비밀번호 재설정 링크를 보내드립니다.
+            </div>
+            <input
+              className="mb-6 w-full rounded-xl border border-border-primary bg-background-secondary px-4 py-[14.5px] text-lg"
+              placeholder="이메일을 입력하세요."
+            />
+            <div className="flex h-12 gap-2">
+              <button
+                onClick={handleClose}
+                className="flex-1 rounded-xl bg-white text-lg font-semibold text-brand-primary"
+              >
+                닫기
+              </button>
+              <button
+                onClick={handleSendLink}
+                className="flex-1 rounded-xl bg-brand-primary text-lg font-semibold text-white"
+              >
+                링크 보내기
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+export default ModalExample;

--- a/src/app/(component)/modal/page.tsx
+++ b/src/app/(component)/modal/page.tsx
@@ -24,41 +24,41 @@ function ModalExample() {
       >
         모달 열기
       </button>
-      {isOpen && (
-        <Modal closeModal={handleClose}>
-          {/**
-           * Modal 컨텐츠 영역
-           * 피그마 예시를 보여주기 위해 디자인에 맞춰 임시로 width: 280px 적용
-           * 작업하실 때 width나 padding으로 조절
-           */}
-          <div className="w-[280px]">
-            <div className="mb-2 text-center text-lg font-medium">
-              비밀번호 재설정
-            </div>
-            <div className="mb-4 text-center text-md text-text-secondary">
-              비밀번호 재설정 링크를 보내드립니다.
-            </div>
-            <input
-              className="mb-6 w-full rounded-xl border border-border-primary bg-background-secondary px-4 py-[14.5px] text-lg"
-              placeholder="이메일을 입력하세요."
-            />
-            <div className="flex h-12 gap-2">
-              <button
-                onClick={handleClose}
-                className="flex-1 rounded-xl bg-white text-lg font-semibold text-brand-primary"
-              >
-                닫기
-              </button>
-              <button
-                onClick={handleSendLink}
-                className="flex-1 rounded-xl bg-brand-primary text-lg font-semibold text-white"
-              >
-                링크 보내기
-              </button>
-            </div>
+      {/* {isOpen && ( */}
+      <Modal isOpen={isOpen} closeModal={handleClose}>
+        {/**
+         * Modal 컨텐츠 영역
+         * 피그마 예시를 보여주기 위해 디자인에 맞춰 임시로 width: 280px 적용
+         * 작업하실 때 width나 padding으로 조절
+         */}
+        <div className="w-[280px]">
+          <div className="mb-2 text-center text-lg font-medium">
+            비밀번호 재설정
           </div>
-        </Modal>
-      )}
+          <div className="mb-4 text-center text-md text-text-secondary">
+            비밀번호 재설정 링크를 보내드립니다.
+          </div>
+          <input
+            className="mb-6 w-full rounded-xl border border-border-primary bg-background-secondary px-4 py-[14.5px] text-lg"
+            placeholder="이메일을 입력하세요."
+          />
+          <div className="flex h-12 gap-2">
+            <button
+              onClick={handleClose}
+              className="flex-1 rounded-xl bg-white text-lg font-semibold text-brand-primary"
+            >
+              닫기
+            </button>
+            <button
+              onClick={handleSendLink}
+              className="flex-1 rounded-xl bg-brand-primary text-lg font-semibold text-white"
+            >
+              링크 보내기
+            </button>
+          </div>
+        </div>
+      </Modal>
+      {/* )} */}
     </div>
   );
 }

--- a/src/app/components/common/modal/Modal.tsx
+++ b/src/app/components/common/modal/Modal.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { PropsWithChildren, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import IconClose from '@/app/components/icons/IconClose';
+
+interface ModalProps {
+  hasCloseBtn?: boolean;
+  portalRoot?: HTMLElement;
+  closeModal: () => void;
+}
+
+function Modal({
+  hasCloseBtn = false,
+  portalRoot, // Modal 렌더링할 상위 DOM 노드
+  closeModal,
+  children,
+}: PropsWithChildren<ModalProps>) {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center max-[744px]:justify-end">
+      <div
+        className="absolute inset-0 bg-black opacity-50"
+        onClick={closeModal}
+      />
+      <div
+        className={`bg-background-secondary relative flex w-96 flex-col items-center rounded-xl pb-8 pt-12 max-[744px]:w-full max-[744px]:rounded-b-none`}
+      >
+        {hasCloseBtn && (
+          <button
+            type="button"
+            className="absolute right-4 top-4 h-6 w-6"
+            title="모달 닫기"
+            onClick={closeModal}
+          >
+            <IconClose />
+          </button>
+        )}
+        {children}
+      </div>
+    </div>,
+    portalRoot || document.body,
+  );
+}
+
+export default Modal;

--- a/src/app/components/common/modal/Modal.tsx
+++ b/src/app/components/common/modal/Modal.tsx
@@ -50,7 +50,7 @@ function Modal({
     >
       <div ref={modalRef} className="absolute inset-0 bg-black opacity-50" />
       <div
-        className={`relative flex w-full transform flex-col items-center rounded-t-xl bg-background-secondary pb-8 pt-12 transition-transform md:w-96 md:rounded-b-xl ${isOpen ? 'translate-y-0' : 'translate-y-4'}`}
+        className={`relative flex max-h-[80%] w-full transform flex-col items-center overflow-y-scroll rounded-t-xl bg-background-secondary pb-8 pt-12 transition-transform md:w-96 md:rounded-b-xl ${isOpen ? 'translate-y-0' : 'translate-y-4'}`}
       >
         {hasCloseBtn && (
           <button

--- a/src/app/components/common/modal/Modal.tsx
+++ b/src/app/components/common/modal/Modal.tsx
@@ -7,7 +7,7 @@ import IconClose from '@/app/components/icons/IconClose';
 interface ModalProps {
   hasCloseBtn?: boolean;
   portalRoot?: HTMLElement;
-  isOpen?: boolean;
+  isOpen: boolean;
   closeModal: () => void;
 }
 
@@ -18,12 +18,22 @@ function Modal({
   isOpen,
   children,
 }: PropsWithChildren<ModalProps>) {
-  const [isMounted, setIsMounted] = useState(false);
+  const [renderModal, setRenderModal] = useState(isOpen);
   const modalRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    setIsMounted(true);
+    if (isOpen) {
+      setRenderModal(true); // isOpen이 true면 렌더링 활성화
+    }
+  }, [isOpen]);
 
+  const handleAnimationEnd = () => {
+    if (!isOpen) {
+      setRenderModal(false); // 애니메이션 종료 후 렌더링 중단
+    }
+  };
+
+  useEffect(() => {
     // 모달 외부 클릭 시 닫히도록 이벤트 처리
     const handleClickOutside = (event: MouseEvent) => {
       if (modalRef.current && modalRef.current.contains(event.target as Node)) {
@@ -40,17 +50,19 @@ function Modal({
     };
   }, [closeModal]);
 
-  if (!isMounted) return null;
+  if (!renderModal) return null;
 
   return createPortal(
     <div
       className={`fixed inset-0 z-50 flex flex-col items-center justify-end transition-opacity md:justify-center ${
-        isOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
+        isOpen ? 'opacity-100' : 'pointer-events-none hidden opacity-0'
       }`}
+      style={{ display: renderModal ? 'flex' : 'none' }}
     >
       <div ref={modalRef} className="absolute inset-0 bg-black opacity-50" />
       <div
         className={`relative flex max-h-[80%] w-full transform flex-col items-center overflow-y-hidden rounded-t-xl bg-background-secondary pb-8 pt-12 transition-transform md:w-96 md:rounded-b-xl ${isOpen ? 'translate-y-0' : 'translate-y-4'}`}
+        onTransitionEnd={handleAnimationEnd}
       >
         {hasCloseBtn && (
           <button

--- a/src/app/components/common/modal/Modal.tsx
+++ b/src/app/components/common/modal/Modal.tsx
@@ -54,14 +54,14 @@ function Modal({
 
   return createPortal(
     <div
-      className={`fixed inset-0 z-50 flex flex-col items-center justify-end transition-opacity md:justify-center ${
+      className={`tablet:justify-center fixed inset-0 z-50 flex flex-col items-center justify-end transition-opacity ${
         isOpen ? 'opacity-100' : 'pointer-events-none hidden opacity-0'
       }`}
       style={{ display: renderModal ? 'flex' : 'none' }}
     >
       <div ref={modalRef} className="absolute inset-0 bg-black opacity-50" />
       <div
-        className={`relative flex max-h-[80%] w-full transform flex-col items-center overflow-y-hidden rounded-t-xl bg-background-secondary pb-8 pt-12 transition-transform md:w-96 md:rounded-b-xl ${isOpen ? 'translate-y-0' : 'translate-y-4'}`}
+        className={`tablet:w-96 tablet:rounded-b-xl relative flex max-h-[80%] w-full transform flex-col items-center overflow-y-hidden rounded-t-xl bg-background-secondary pb-8 pt-12 transition-transform ${isOpen ? 'translate-y-0' : 'translate-y-4'}`}
         onTransitionEnd={handleAnimationEnd}
       >
         {hasCloseBtn && (

--- a/src/app/components/common/modal/Modal.tsx
+++ b/src/app/components/common/modal/Modal.tsx
@@ -50,7 +50,7 @@ function Modal({
     >
       <div ref={modalRef} className="absolute inset-0 bg-black opacity-50" />
       <div
-        className={`relative flex max-h-[80%] w-full transform flex-col items-center overflow-y-scroll rounded-t-xl bg-background-secondary pb-8 pt-12 transition-transform md:w-96 md:rounded-b-xl ${isOpen ? 'translate-y-0' : 'translate-y-4'}`}
+        className={`relative flex max-h-[80%] w-full transform flex-col items-center overflow-y-hidden rounded-t-xl bg-background-secondary pb-8 pt-12 transition-transform md:w-96 md:rounded-b-xl ${isOpen ? 'translate-y-0' : 'translate-y-4'}`}
       >
         {hasCloseBtn && (
           <button

--- a/src/app/components/common/modal/Modal.tsx
+++ b/src/app/components/common/modal/Modal.tsx
@@ -7,6 +7,7 @@ import IconClose from '@/app/components/icons/IconClose';
 interface ModalProps {
   hasCloseBtn?: boolean;
   portalRoot?: HTMLElement;
+  isOpen?: boolean;
   closeModal: () => void;
 }
 
@@ -14,6 +15,7 @@ function Modal({
   hasCloseBtn = false,
   portalRoot, // Modal 렌더링할 상위 DOM 노드
   closeModal,
+  isOpen,
   children,
 }: PropsWithChildren<ModalProps>) {
   const [isMounted, setIsMounted] = useState(false);
@@ -41,9 +43,15 @@ function Modal({
   if (!isMounted) return null;
 
   return createPortal(
-    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center max-[744px]:justify-end">
+    <div
+      className={`fixed inset-0 z-50 flex flex-col items-center justify-end transition-opacity md:justify-center ${
+        isOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
+      }`}
+    >
       <div ref={modalRef} className="absolute inset-0 bg-black opacity-50" />
-      <div className="relative flex w-96 flex-col items-center rounded-xl bg-background-secondary pb-8 pt-12 max-[744px]:w-full max-[744px]:rounded-b-none">
+      <div
+        className={`relative flex w-full transform flex-col items-center rounded-t-xl bg-background-secondary pb-8 pt-12 transition-transform md:w-96 md:rounded-b-xl ${isOpen ? 'translate-y-0' : 'translate-y-4'}`}
+      >
         {hasCloseBtn && (
           <button
             type="button"

--- a/src/app/components/common/modal/Modal.tsx
+++ b/src/app/components/common/modal/Modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PropsWithChildren, useEffect, useState } from 'react';
+import { PropsWithChildren, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import IconClose from '@/app/components/icons/IconClose';
 
@@ -17,22 +17,33 @@ function Modal({
   children,
 }: PropsWithChildren<ModalProps>) {
   const [isMounted, setIsMounted] = useState(false);
+  const modalRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     setIsMounted(true);
-  }, []);
+
+    // 모달 외부 클릭 시 닫히도록 이벤트 처리
+    const handleClickOutside = (event: MouseEvent) => {
+      if (modalRef.current && modalRef.current.contains(event.target as Node)) {
+        closeModal();
+      }
+    };
+
+    // 마운트 시 이벤트 리스너 추가
+    document.addEventListener('mousedown', handleClickOutside);
+
+    // clean-up : 언마운트 시 이벤트 리스너 제거
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [closeModal]);
 
   if (!isMounted) return null;
 
   return createPortal(
     <div className="fixed inset-0 z-50 flex flex-col items-center justify-center max-[744px]:justify-end">
-      <div
-        className="absolute inset-0 bg-black opacity-50"
-        onClick={closeModal}
-      />
-      <div
-        className={`bg-background-secondary relative flex w-96 flex-col items-center rounded-xl pb-8 pt-12 max-[744px]:w-full max-[744px]:rounded-b-none`}
-      >
+      <div ref={modalRef} className="absolute inset-0 bg-black opacity-50" />
+      <div className="relative flex w-96 flex-col items-center rounded-xl bg-background-secondary pb-8 pt-12 max-[744px]:w-full max-[744px]:rounded-b-none">
         {hasCloseBtn && (
           <button
             type="button"

--- a/src/app/components/icons/IconClose.tsx
+++ b/src/app/components/icons/IconClose.tsx
@@ -1,0 +1,28 @@
+function IconClose() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M18 6L6 18"
+        stroke="#64748B"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6 6L18 18"
+        stroke="#64748B"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default IconClose;

--- a/src/app/hooks/useModal.ts
+++ b/src/app/hooks/useModal.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useState } from 'react';
+
+interface ModalHookProps {
+  initialState?: boolean;
+}
+
+function useModal({ initialState = false }: ModalHookProps = {}) {
+  const [isOpen, setIsOpen] = useState(initialState);
+
+  const openModal = () => setIsOpen(true);
+  const closeModal = () => setIsOpen(false);
+
+  return { isOpen, openModal, closeModal };
+}
+
+export default useModal;


### PR DESCRIPTION
### 이슈 번호
close #17 

### 변경 사항 요약
- [x] 모달 기능 구현
- [x] useModal 커스텀 훅 구현
- [x] React Portal을 활용해 DOM 노드의 body 하위에 위치
### 테스트 결과
#### 동작
![Coworkers-Chrome-2025-01-18-22-59-01](https://github.com/user-attachments/assets/2679bafc-8e57-4d5d-894a-52126d8baee7)
#### Mobile
![image](https://github.com/user-attachments/assets/22329d83-7cea-4b59-9b80-9fc8a55f37ce)
#### PC & Tablet
![image](https://github.com/user-attachments/assets/a28a8779-f60b-4212-a9fe-42208184bc95)



### 리뷰포인트
> 모달 컨텐츠 영역(children)의 넓이를 따로 설정하지 않았습니다.
> app/(component)/modal/page.tsx 에서 사용한 것처럼 페이지에서 작업 시 추가하도록 했습니다.
> 확인해보시고 Modal 컴포넌트에서 처리하는게 편하시면 수정하겠습니다.