### PR TITLE
비밀번호 재설정하는 모달추가완료, 페이지 완성완료, api연동완료

### DIFF
--- a/src/app/(routes)/reset-password/page.tsx
+++ b/src/app/(routes)/reset-password/page.tsx
@@ -1,0 +1,5 @@
+import ResetPasswordForm from '@/app/components/resetpassword/ResetPasswordForm';
+
+export default function ResetPasswordPage() {
+  return <ResetPasswordForm />;
+}

--- a/src/app/components/common/button/Button.tsx
+++ b/src/app/components/common/button/Button.tsx
@@ -17,6 +17,7 @@ interface ButtonProps {
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   disabled?: boolean;
   className?: string;
+  type?: 'button' | 'submit' | 'reset';
 }
 
 function Button({
@@ -26,6 +27,7 @@ function Button({
   onClick,
   disabled = false,
   className,
+  type,
 }: ButtonProps) {
   const baseStyles = 'items-center font-semibold justify-center';
 
@@ -89,6 +91,7 @@ function Button({
       )}
       onClick={onClick}
       disabled={disabled}
+      type={type}
     >
       <span className="flex items-center justify-center gap-1">{children}</span>
     </button>

--- a/src/app/components/login/LoginForm.tsx
+++ b/src/app/components/login/LoginForm.tsx
@@ -6,11 +6,16 @@ import Input from '@/app/components/common/input/Input';
 import Button from '@/app/components/common/button/Button';
 import { FormData } from '@/app/types/AuthType';
 import useSignIn from '@/app/hooks/useSignIn';
+import useModal from '@/app/hooks/useModal';
+import ResetPasswordModal from './ResetPasswordModal';
 
 export default function LoginComponent() {
+  const { isOpen, openModal, closeModal } = useModal();
+
   const methods = useForm<FormData>({
     mode: 'onChange',
   });
+
   const signInMutation = useSignIn();
 
   const onSubmit = (data: FormData) => {
@@ -18,66 +23,74 @@ export default function LoginComponent() {
   };
 
   return (
-    <div className="mt-16 px-4 tablet:mx-auto tablet:w-[28.75rem] tablet:px-0">
-      <h3 className="pb-6 pt-6 text-center text-2xl tablet:pb-20 tablet:pt-[6.25rem] xl:text-4xl">
-        로그인
-      </h3>
-      <FormProvider {...methods}>
-        <form onSubmit={methods.handleSubmit(onSubmit)}>
-          <div className="flex flex-col gap-6">
-            <Input
-              name="email"
-              title="이메일"
-              type="email"
-              placeholder="이메일을 입력해주세요"
-              autoComplete="email"
-              validationRules={{
-                required: '유효한 이메일이 아닙니다.',
-                pattern: {
-                  value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-                  message: '이메일 형식으로 작성해 주세요.',
-                },
-              }}
-            />
-            <Input
-              name="password"
-              title="비밀번호"
-              type="password"
-              placeholder="비밀번호를 입력해주세요."
-              autoComplete="new-password"
-              validationRules={{
-                required: '비밀번호를 입력해주세요.',
-                pattern: {
-                  value:
-                    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,20}$/,
-                  message:
-                    '비밀번호는 8~20자의 숫자, 영문, 특수문자가 포함되어야 합니다.',
-                },
-              }}
-            />
-          </div>
-          <button className="mb-10 mt-3 flex justify-self-end text-md text-brand-primary underline tablet:text-lg">
-            비밀번호를 잊으셨나요?
-          </button>
-          <Button
-            className="w-full text-white"
-            disabled={!methods.formState.isValid}
+    <>
+      <div className="mt-16 px-4 tablet:mx-auto tablet:w-[28.75rem] tablet:px-0">
+        <h3 className="pb-6 pt-6 text-center text-2xl tablet:pb-20 tablet:pt-[6.25rem] xl:text-4xl">
+          로그인
+        </h3>
+        <FormProvider {...methods}>
+          <form onSubmit={methods.handleSubmit(onSubmit)}>
+            <div className="flex flex-col gap-6">
+              <Input
+                name="email"
+                title="이메일"
+                type="email"
+                placeholder="이메일을 입력해주세요"
+                autoComplete="email"
+                validationRules={{
+                  required: '유효한 이메일이 아닙니다.',
+                  pattern: {
+                    value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                    message: '이메일 형식으로 작성해 주세요.',
+                  },
+                }}
+              />
+              <Input
+                name="password"
+                title="비밀번호"
+                type="password"
+                placeholder="비밀번호를 입력해주세요."
+                autoComplete="new-password"
+                validationRules={{
+                  required: '비밀번호를 입력해주세요.',
+                  pattern: {
+                    value:
+                      /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,20}$/,
+                    message:
+                      '비밀번호는 8~20자의 숫자, 영문, 특수문자가 포함되어야 합니다.',
+                  },
+                }}
+              />
+            </div>
+            <button
+              type="button"
+              onClick={openModal}
+              className="mb-10 mt-3 flex justify-self-end text-md text-brand-primary underline tablet:text-lg"
+            >
+              비밀번호를 잊으셨나요?
+            </button>
+            <Button
+              type="submit"
+              className="w-full text-white"
+              disabled={!methods.formState.isValid}
+            >
+              로그인
+            </Button>
+          </form>
+        </FormProvider>
+        <div className="mt-6 flex justify-center gap-3">
+          <p className="text-md text-text-primary tablet:text-lg">
+            아직 계정이 없으신가요?
+          </p>
+          <Link
+            className="text-md text-brand-primary underline tablet:text-lg"
+            href="/signup"
           >
-            로그인
-          </Button>
-        </form>
-      </FormProvider>
-      <div className="mt-6 flex justify-center gap-3">
-        <p className="text-md text-text-primary tablet:text-lg">
-          아직 계정이 없으신가요?
-        </p>
-        <Link
-          className="text-md text-brand-primary underline tablet:text-lg"
-          href="/signup"
-        >
-          가입하기
-        </Link>
+            가입하기
+          </Link>
+        </div>
       </div>
-    </div>
+      <ResetPasswordModal isOpen={isOpen} closeModal={closeModal} />
+    </>
   );
 }

--- a/src/app/components/login/ResetPasswordModal.tsx
+++ b/src/app/components/login/ResetPasswordModal.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React from 'react';
+import Input from '@/app/components/common/input/Input';
+import Button from '@/app/components/common/button/Button';
+import Modal from '@/app/components/common/modal/Modal';
+import { useForm, FormProvider, SubmitHandler } from 'react-hook-form';
+import useResetPassword from '@/app/hooks/useResetPassword';
+
+interface ResetPasswordModalProps {
+  isOpen: boolean;
+  closeModal: () => void;
+}
+
+interface FormValues {
+  email: string;
+}
+
+export default function ResetPasswordModal({
+  isOpen,
+  closeModal,
+}: ResetPasswordModalProps) {
+  const resetPasswordMutation = useResetPassword();
+  const methods = useForm<FormValues>();
+
+  const onSubmit: SubmitHandler<FormValues> = (data) => {
+    const redirectUrl = 'http://localhost:3000/'; // 배포한 url 나중에 변경할 예정
+
+    resetPasswordMutation.mutate(
+      {
+        email: data.email,
+        redirectUrl,
+      },
+      {
+        onSuccess: () => {
+          closeModal();
+        },
+      },
+    );
+  };
+
+  const handleClose = () => {
+    closeModal();
+  };
+
+  return (
+    <Modal isOpen={isOpen} closeModal={closeModal}>
+      <FormProvider {...methods}>
+        <form onSubmit={methods.handleSubmit(onSubmit)}>
+          <div className="max-w-[17.5rem]">
+            <p className="text-center">비밀번호 재설정</p>
+            <p className="text-center text-md text-text-secondary">
+              비밀번호 재설정 링크를 보내드립니다.
+            </p>
+            <Input
+              name="email"
+              title=""
+              type="email"
+              placeholder="이메일을 입력하세요."
+              autoComplete="email"
+              validationRules={{
+                required: '이메일을 입력해주세요.',
+                pattern: {
+                  value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                  message: '유효한 이메일 주소를 입력해주세요.',
+                },
+              }}
+            />
+            <div className="mt-4 flex gap-2">
+              <Button type="button" variant="inverse" onClick={handleClose}>
+                닫기
+              </Button>
+              <Button type="submit" className="text-white">
+                링크 보내기
+              </Button>
+            </div>
+          </div>
+        </form>
+      </FormProvider>
+    </Modal>
+  );
+}

--- a/src/app/components/resetpassword/ResetPasswordForm.tsx
+++ b/src/app/components/resetpassword/ResetPasswordForm.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { useForm, FormProvider } from 'react-hook-form';
+import Input from '@/app/components/common/input/Input';
+import Button from '@/app/components/common/button/Button';
+import useConfirmPassword from '@/app/hooks/useConfirmPassword';
+import { ConfirmPasswordType } from '@/app/types/AuthType';
+
+export default function ResetPasswordForm() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token');
+  const { mutate } = useConfirmPassword();
+
+  const methods = useForm<ConfirmPasswordType>({
+    mode: 'onChange',
+  });
+
+  const onSubmit = (data: ConfirmPasswordType) => {
+    if (!token) {
+      alert('유효하지 않은 토큰입니다.');
+      return;
+    }
+    mutate({
+      password: data.password,
+      passwordConfirmation: data.passwordConfirmation,
+      token,
+    });
+  };
+
+  return (
+    <div className="mt-16 px-4 tablet:mx-auto tablet:w-[28.75rem] tablet:px-0">
+      <h3 className="pb-6 pt-6 text-center text-2xl tablet:pb-20 tablet:pt-[6.25rem] xl:text-4xl">
+        비밀번호 재설정
+      </h3>
+      <FormProvider {...methods}>
+        <form onSubmit={methods.handleSubmit(onSubmit)}>
+          <div className="mb-10 flex flex-col gap-6">
+            <Input
+              name="password"
+              title="비밀번호"
+              type="password"
+              placeholder="비밀번호(영문,숫자포함,12자이내)를 입력해주세요."
+              autoComplete="new-password"
+              validationRules={{
+                required: '비밀번호를 입력해주세요.',
+                pattern: {
+                  value:
+                    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,20}$/,
+                  message:
+                    '비밀번호는 8~20자의 숫자, 영문, 특수문자가 포함되어야 합니다.',
+                },
+              }}
+            />
+            <Input
+              name="passwordConfirmation"
+              title="비밀번호 확인"
+              type="password"
+              placeholder="새 비밀번호를 다시 한번 입력해주세요."
+              autoComplete="new-password"
+              validationRules={{
+                required: '비밀번호 확인을 입력해주세요.',
+                validate: (value) =>
+                  value === methods.getValues('password') ||
+                  '비밀번호가 일치하지 않습니다.',
+              }}
+            />
+          </div>
+          <Button
+            type="submit"
+            className="w-full text-white"
+            disabled={!methods.formState.isValid}
+          >
+            재설정
+          </Button>
+        </form>
+      </FormProvider>
+    </div>
+  );
+}

--- a/src/app/hooks/useConfirmPassword.ts
+++ b/src/app/hooks/useConfirmPassword.ts
@@ -1,0 +1,20 @@
+import { useMutation } from '@tanstack/react-query';
+import patchResetPasswordApi from '@/app/lib/user/patchResetPasswordApi';
+import { ConfirmPasswordType } from '@/app/types/AuthType';
+import { useRouter } from 'next/navigation';
+
+const useConfirmPassword = () => {
+  const router = useRouter();
+  return useMutation({
+    mutationFn: (data: ConfirmPasswordType) => patchResetPasswordApi(data),
+    onSuccess: () => {
+      alert('비밀번호 재설정이 완료되었습니다.');
+      router.push('/login');
+    },
+    onError: (error: Error) => {
+      alert(error.message);
+    },
+  });
+};
+
+export default useConfirmPassword;

--- a/src/app/hooks/useResetPassword.ts
+++ b/src/app/hooks/useResetPassword.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+import postResetPasswordApi from '@/app/lib/user/postResetPasswordApi';
+import { ResetPasswordType } from '@/app/types/AuthType';
+
+const useResetPassword = () => {
+  return useMutation({
+    mutationFn: (data: ResetPasswordType) => postResetPasswordApi(data),
+    onSuccess: (data) => {
+      alert(data.message);
+    },
+    onError: (error: Error) => {
+      alert(error.message);
+    },
+  });
+};
+
+export default useResetPassword;

--- a/src/app/lib/instance.ts
+++ b/src/app/lib/instance.ts
@@ -13,11 +13,8 @@ instance.interceptors.request.use((config) => {
   const state = store.getState();
   const token = state.auth.accessToken;
 
-  console.log('현재 토큰:', token); // 토큰 값 콘솔 출력
-
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
-    console.log('Authorization 헤더:', config.headers.Authorization);
   }
 
   return config;

--- a/src/app/lib/user/patchResetPasswordApi.ts
+++ b/src/app/lib/user/patchResetPasswordApi.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import { ConfirmPasswordType, ResetMessage } from '@/app/types/AuthType';
+import instance from '@/app/lib/instance';
+
+const patchResetPasswordApi = async (
+  confirmPassword: ConfirmPasswordType,
+): Promise<ResetMessage> => {
+  try {
+    const response = await instance.patch<ResetMessage>(
+      '/user/reset-password',
+      confirmPassword,
+    );
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const message =
+        error.response.data?.message || '비밀번호 초기화를 실패했습니다.';
+      throw new Error(message);
+    }
+    throw new Error(
+      '네트워크 또는 기타 문제로 인해 비밀번호 초기화를 실패했습니다.',
+    );
+  }
+};
+
+export default patchResetPasswordApi;

--- a/src/app/lib/user/postResetPasswordApi.ts
+++ b/src/app/lib/user/postResetPasswordApi.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import { ResetPasswordType, ResetMessage } from '@/app/types/AuthType';
+import instance from '@/app/lib/instance';
+
+const postResetPasswordApi = async (
+  resetPassword: ResetPasswordType,
+): Promise<ResetMessage> => {
+  try {
+    const response = await instance.post<ResetMessage>(
+      '/user/send-reset-password-email',
+      resetPassword,
+    );
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const message =
+        error.response.data?.message || '링크 전송에 실패했습니다.';
+      throw new Error(message);
+    }
+    throw new Error('네트워크 또는 기타 문제로 인해 링크 전송에 실패했습니다.');
+  }
+};
+
+export default postResetPasswordApi;

--- a/src/app/providers/ReduxProvider.tsx
+++ b/src/app/providers/ReduxProvider.tsx
@@ -1,10 +1,15 @@
 'use client';
 
-import { PersistGate } from 'redux-persist/integration/react';
 import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
 import { store, persistor } from '@/app/stores/store';
+import { ReactNode } from 'react';
 
-function ReduxProvider({ children }: { children: React.ReactNode }) {
+interface ReduxProviderProps {
+  children: ReactNode;
+}
+
+export default function ReduxProvider({ children }: ReduxProviderProps) {
   return (
     <Provider store={store}>
       <PersistGate loading={null} persistor={persistor}>
@@ -13,5 +18,3 @@ function ReduxProvider({ children }: { children: React.ReactNode }) {
     </Provider>
   );
 }
-
-export default ReduxProvider;

--- a/src/app/stores/store.ts
+++ b/src/app/stores/store.ts
@@ -2,12 +2,29 @@
 
 import { configureStore } from '@reduxjs/toolkit';
 import { persistStore, persistReducer } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
 import { combineReducers } from 'redux';
 import authReducer from '@/app/stores/auth/authSlice';
+import createWebStorage from 'redux-persist/lib/storage/createWebStorage';
 
+const createNoopStorage = () => {
+  return {
+    getItem() {
+      return Promise.resolve(null);
+    },
+    setItem(_key: string, value: string) {
+      return Promise.resolve(value);
+    },
+    removeItem() {
+      return Promise.resolve();
+    },
+  };
+};
+const storage =
+  typeof window === 'undefined'
+    ? createNoopStorage()
+    : createWebStorage('local');
 // Persist 설정 간소화
-const persistConfig = {
+const rootPersistConfig = {
   key: 'root',
   storage,
   // 특정 리듀서만 영구 저장
@@ -20,7 +37,7 @@ const rootReducer = combineReducers({
 });
 
 // Persist 리듀서 생성
-const persistedReducer = persistReducer(persistConfig, rootReducer);
+const persistedReducer = persistReducer(rootPersistConfig, rootReducer);
 
 // 스토어 생성
 const store = configureStore({

--- a/src/app/types/AuthType.ts
+++ b/src/app/types/AuthType.ts
@@ -27,3 +27,18 @@ export interface SignInResponse {
     teamId: string;
   };
 }
+
+export interface ResetPasswordType {
+  email: string;
+  redirectUrl: string;
+}
+
+export interface ConfirmPasswordType {
+  password: string;
+  passwordConfirmation: string;
+  token: string;
+}
+
+export interface ResetMessage {
+  message: string;
+}


### PR DESCRIPTION
### 이슈 번호

- #26 

### 변경 사항 요약

- `npm run dev` 환경에서 `redux-persist failed to create sync storage. falling back to noop storage.`
- 오류가 계속 생겨 `store.ts`, `ReduxProvider.tsx` 저장소 실패문제일수도 있고 SSR 환경에서 발생하는 문제일수도 있어서 2가지 모두 찾아 오류해결완료
- 공통컴퍼넌트 버튼에 `type`추가

### 테스트 결과

#### pc
![FireShot Capture 242 - Coworkers - localhost](https://github.com/user-attachments/assets/d5a601c6-3da6-4d5a-a00c-463e4ac2d00e)

#### mobile
![FireShot Capture 241 - Coworkers - localhost](https://github.com/user-attachments/assets/f8a8c051-16d7-4337-b902-4b2dacd3907e)

#### 링크보내기 클릭
![image](https://github.com/user-attachments/assets/e7031ae8-16dd-463f-9fa1-b72d0adefbf0)

#### 해당 메일가서 확인
![image](https://github.com/user-attachments/assets/e6dbb97d-6077-426e-b554-3978c24e5880)

#### 링크 클릭하면 비밀번호 재설정 페이지로 이동 모바일 화면
![FireShot Capture 244 - Coworkers - localhost](https://github.com/user-attachments/assets/806da865-4ec4-492e-be4e-82fac01f5c77)

#### 유효성 검사 pc 화면 
![FireShot Capture 245 - Coworkers - localhost](https://github.com/user-attachments/assets/85454aae-e0a9-464c-b72a-893c6bb7c628)

#### 재설정 완료화면 확인하면 로그인페이지로 이동

![image](https://github.com/user-attachments/assets/bde82ae3-c710-41d1-9f6b-a59bfcab0aa1)


### 리뷰포인트

- 현재 redirectUrl이 로컬이긴한데 feature브랜치로 mrege할떄 배포 url로 수정할예정
- 오류가 없는지 확인부탁드립니다~
- 퍼블리싱 문제가 있는지 확인부탁드립니다~
