### PR TITLE
Header 부분 로그인후 보이는 프로필이미지, 드랍다운 구현완료

### DIFF
--- a/src/app/components/common/header/Header.tsx
+++ b/src/app/components/common/header/Header.tsx
@@ -66,7 +66,9 @@ export default function Header() {
               </Link>
             </div>
             {/* 자유게시판 버튼 */}
-            <HeaderBoardButton className="hidden tablet:block" />
+            {isLoggedIn && (
+              <HeaderBoardButton className="hidden tablet:block" />
+            )}
           </div>
           <div>
             {isLoggedIn ? (

--- a/src/app/components/common/header/Header.tsx
+++ b/src/app/components/common/header/Header.tsx
@@ -3,28 +3,57 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useRouter } from 'next/navigation';
+import { RootState } from '@/app/stores/store';
+import { logout } from '@/app/stores/auth/authSlice';
 import SideMenuBar from '@/app/components/common/header/SideMenubar';
 import HeaderMenuBar from '@/app/components/icons/HeaderMenuBar';
 import HeaderBoardButton from '@/app/components/common/header/Boards';
+import HeaderUserIcon from '@/app/components/icons/HeaderUserIcon';
+import Dropdown from '@/app/components/common/dropdown/Dropdown';
+import DropdownItem from '@/app/components/common/dropdown/DropdownItem';
+import DropdownList from '@/app/components/common/dropdown/DropdownList';
+import useDropdown from '@/app/hooks/useDropdown';
 
 export default function Header() {
   const [visible, setVisible] = useState<boolean>(false);
+  const { isOpen, toggleDropdown, closeDropdown } = useDropdown();
+  const dispatch = useDispatch();
+  const router = useRouter();
+
+  const { user, accessToken } = useSelector((state: RootState) => state.auth);
+
+  const isLoggedIn = !!accessToken;
 
   const handleOpenSlideMenubar = (): void => setVisible(true);
   const handleCloseSlideMenubar = (): void => setVisible(false);
 
+  const handleLogout = (): void => {
+    dispatch(logout());
+    router.push('/');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      toggleDropdown(e);
+    }
+  };
+
   return (
     <>
-      <header className="fixed left-0 top-0 z-40 w-full bg-background-secondary px-4 py-5 tablet:px-6 xl:px-0 xl:py-3">
-        <div className="mx-auto flex items-center justify-between xl:max-w-[75rem]">
+      <header className="fixed left-0 top-0 z-40 h-[3.75rem] w-full bg-background-secondary px-4 tablet:px-6 xl:px-0">
+        <div className="mx-auto flex h-full items-center justify-between xl:max-w-[75rem]">
           <div className="flex items-center gap-4 tablet:gap-8 xl:gap-10">
-            <button
-              className="tablet:hidden"
-              onClick={handleOpenSlideMenubar}
-              aria-label="Open Menu"
-            >
-              <HeaderMenuBar />
-            </button>
+            {isLoggedIn && (
+              <button
+                className="tablet:hidden"
+                onClick={handleOpenSlideMenubar}
+                aria-label="Open Menu"
+              >
+                <HeaderMenuBar />
+              </button>
+            )}
             <div className="h-5 w-[6.3rem] xl:h-8 xl:w-[9.8rem]">
               <Link className="block h-full w-full" href="/">
                 <Image
@@ -40,12 +69,71 @@ export default function Header() {
             <HeaderBoardButton className="hidden tablet:block" />
           </div>
           <div>
-            <Link
-              className="text-md hover:text-interaction-hover xl:text-base"
-              href="/login"
-            >
-              로그인
-            </Link>
+            {isLoggedIn ? (
+              <div
+                className="relative flex cursor-pointer items-center gap-2"
+                onClick={toggleDropdown}
+                role="button"
+                tabIndex={0}
+                onKeyDown={handleKeyDown}
+              >
+                <HeaderUserIcon />
+                <span className="hidden hover:text-interaction-hover xl:block">
+                  {user?.nickname || '사용자'}
+                </span>
+
+                <Dropdown
+                  className="right-28 top-4 xl:right-[8rem] xl:top-7"
+                  onClose={closeDropdown}
+                >
+                  <DropdownList className="w-28 xl:w-[135px]" isOpen={isOpen}>
+                    <DropdownItem
+                      className="xl:text-base"
+                      onClick={() => {
+                        closeDropdown();
+                        router.push('/myhistory');
+                      }}
+                    >
+                      마이 히스토리
+                    </DropdownItem>
+                    <DropdownItem
+                      className="xl:text-base"
+                      onClick={() => {
+                        closeDropdown();
+                        router.push('/mypage');
+                      }}
+                    >
+                      계정 설정
+                    </DropdownItem>
+                    <DropdownItem
+                      className="xl:text-base"
+                      onClick={() => {
+                        closeDropdown();
+                        router.push('/');
+                      }}
+                    >
+                      팀 참여
+                    </DropdownItem>
+                    <DropdownItem
+                      className="xl:text-base"
+                      onClick={() => {
+                        closeDropdown();
+                        handleLogout();
+                      }}
+                    >
+                      로그아웃
+                    </DropdownItem>
+                  </DropdownList>
+                </Dropdown>
+              </div>
+            ) : (
+              <Link
+                className="text-md hover:text-interaction-hover xl:text-base"
+                href="/login"
+              >
+                로그인
+              </Link>
+            )}
           </div>
         </div>
       </header>

--- a/src/app/hooks/useDropdown.ts
+++ b/src/app/hooks/useDropdown.ts
@@ -4,7 +4,7 @@ function useDropdown() {
   const [isOpen, setIsOpen] = useState(false);
   const [currentItem, setCurrentItem] = useState<string | null>(null);
 
-  const toggleDropdown = (e: React.MouseEvent) => {
+  const toggleDropdown = (e: React.MouseEvent | React.KeyboardEvent) => {
     e.stopPropagation();
     setIsOpen((prev) => !prev);
   };


### PR DESCRIPTION
### 이슈 번호

- #18 

### 변경 사항 요약

- 로그인후 프로필이미지 + 닉네임 보이게 ui 구현완료
- 프로필 클릭시 드랍다운으로 메뉴 구현완료
- useDropDown.ts에 토글 함수의 이벤트 타입 확장

### 테스트 결과

#### 로그인전 pc
![FireShot Capture 252 - Coworkers - localhost](https://github.com/user-attachments/assets/37333e26-be62-4c84-a9c6-2d1f9de303c1)

#### 로그인전 mobile
![FireShot Capture 253 - Coworkers - localhost](https://github.com/user-attachments/assets/7361ebb9-e3d0-44f1-a7ff-46edc2cf2c02)

#### 로그인후 pc
![FireShot Capture 250 - Coworkers - localhost](https://github.com/user-attachments/assets/7a50688a-695d-4709-9bec-5792b6c290e3)

#### 로그인후 mobile
![FireShot Capture 251 - Coworkers - localhost](https://github.com/user-attachments/assets/8dcc3deb-2477-4308-9880-db6447236b7d)


### 리뷰포인트

- 로그인후 이미지와 닉네임이 잘보이는지 드랍다운 메뉴를 클릭했을떄 해당 페이지로 잘이동하는 확인부탁드립니다.
- 팀참여 버튼은 어디 페이지로 이동을 해야하나요?
