### PR TITLE
팀 참여하기 로그인 분기 처리 추가

### DIFF
--- a/src/app/(routes)/addteam/page.tsx
+++ b/src/app/(routes)/addteam/page.tsx
@@ -6,13 +6,10 @@ import postGroup from '@/app/lib/group/postGroup';
 import { GroupData } from '@/app/types/group';
 import TeamForm from '@/app/components/team/TeamForm';
 import { useRouter } from 'next/navigation';
-import { useSelector } from 'react-redux';
-import { RootState } from '@/app/stores/store';
-import { useEffect } from 'react';
+import useRedirectLogin from '@/app/hooks/useRedirectLogin';
 
 function Page() {
   const router = useRouter();
-  const { accessToken } = useSelector((state: RootState) => state.auth);
 
   const onSubmit = async ({ profile, name }: FieldValues) => {
     let imageUrl: string | null = null;
@@ -55,12 +52,7 @@ function Page() {
     }
   };
 
-  useEffect(() => {
-    if (!accessToken) {
-      alert('로그인 후 이용할 수 있습니다.');
-      router.push('/login');
-    }
-  }, [accessToken, router]);
+  useRedirectLogin();
 
   return (
     <div>

--- a/src/app/(routes)/invitation/page.tsx
+++ b/src/app/(routes)/invitation/page.tsx
@@ -1,46 +1,41 @@
 'use client';
 
 import Button from '@/app/components/common/button/Button';
+import useRedirectLogin from '@/app/hooks/useRedirectLogin';
 import postAcceptInvitation from '@/app/lib/group/postAcceptInvitation';
+import { RootState } from '@/app/stores/store';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 
 function Page() {
   const router = useRouter();
   const params = useSearchParams();
   const [token, setToken] = useState('');
-  const [groupId, setGroupId] = useState('');
-
-  const [testEmail, setTestEmail] = useState('');
+  const { user } = useSelector((store: RootState) => store.auth);
 
   const handleClick = async () => {
     try {
-      await postAcceptInvitation({
-        /**
-         * 임시로 테스트 계정 추가
-         * 로그인 구현 후 수정
-         */
-        userEmail: 'user03@test.com',
+      const { groupId } = await postAcceptInvitation({
+        userEmail: user?.email || '',
         token,
       });
+
+      router.push(groupId.toString());
     } catch (error) {
       alert('이미 그룹에 소속된 유저입니다.');
     }
-    router.push(groupId);
   };
 
   useEffect(() => {
     const tokenParam = params.get('token');
-    const groupIdParam = params.get('groupId');
 
     if (tokenParam) {
       setToken(tokenParam);
     }
-
-    if (groupIdParam) {
-      setGroupId(groupIdParam);
-    }
   }, [params]);
+
+  useRedirectLogin();
 
   return (
     <div>
@@ -48,14 +43,6 @@ function Page() {
         <h2 className="mb-6 text-center text-2xl font-medium text-text-primary tablet:mb-20">
           팀 참여하기
         </h2>
-        {/* 이메일 입력 input - 로그인 구현 전 임시 테스트를 위한 input */}
-        <input
-          className="mb-4 w-full rounded-xl border border-border-primary bg-background-secondary px-4 py-[0.85rem] disabled:cursor-not-allowed disabled:text-text-default"
-          type="text"
-          placeholder="로그인 기능 구현 전 테스트를 위한 임시 input"
-          value={testEmail}
-          onChange={(e) => setTestEmail(e.target.value)}
-        />
         <div className="mb-3 text-lg font-medium">팀 링크</div>
         <input
           type="text"

--- a/src/app/components/common/header/Header.tsx
+++ b/src/app/components/common/header/Header.tsx
@@ -111,7 +111,7 @@ export default function Header() {
                       className="xl:text-base"
                       onClick={() => {
                         closeDropdown();
-                        router.push('/');
+                        router.push('/invitation');
                       }}
                     >
                       팀 참여

--- a/src/app/hooks/useRedirectLogin.ts
+++ b/src/app/hooks/useRedirectLogin.ts
@@ -1,0 +1,18 @@
+import { useSelector } from 'react-redux';
+import { RootState } from '@/app/stores/store';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+const useRedirectLogin = () => {
+  const router = useRouter();
+  const { accessToken } = useSelector((store: RootState) => store.auth);
+
+  useEffect(() => {
+    if (!accessToken) {
+      alert('로그인 후 이용할 수 있습니다.');
+      router.push('/login');
+    }
+  }, [accessToken, router]);
+};
+
+export default useRedirectLogin;

--- a/src/app/lib/group/deleteMemeber.ts
+++ b/src/app/lib/group/deleteMemeber.ts
@@ -6,11 +6,7 @@ interface DeleteMemberRequest {
 }
 
 const deleteMember = async ({ groupId, userId }: DeleteMemberRequest) => {
-  await axios.delete(`/groups/${groupId}/member/${userId}`, {
-    headers: {
-      Authorization: `Bearer ${process.env.NEXT_PUBLIC_ACCESS_TOKEN}`,
-    },
-  });
+  await axios.delete(`/groups/${groupId}/member/${userId}`, {});
 };
 
 export default deleteMember;

--- a/src/app/lib/group/postAcceptInvitation.ts
+++ b/src/app/lib/group/postAcceptInvitation.ts
@@ -5,14 +5,17 @@ interface AcceptInvitationRequest {
   token: string;
 }
 
+interface AcceptInvitationResponse {
+  groupId: number;
+}
+
 const postAcceptInvitation = async (
   data: AcceptInvitationRequest,
-): Promise<string> => {
-  const res = await axios.post<string>('/groups/accept-invitation', data, {
-    headers: {
-      Authorization: `Bearer ${process.env.NEXT_PUBLIC_ACCESS_TOKEN}`,
-    },
-  });
+): Promise<AcceptInvitationResponse> => {
+  const res = await axios.post<AcceptInvitationResponse>(
+    '/groups/accept-invitation',
+    data,
+  );
 
   return res.data;
 };


### PR DESCRIPTION
### 이슈 번호

#45

### 변경 사항 요약
- 로그인 리다이렉트 커스텀 훅 추가
- 팀 참여하기 페이지 테스트용 input 삭제
- Redux user Email 참조하도록 수정
- 헤더 드롭다운 메뉴 `참여하기` 버튼 클릭 시 팀 참여하기(/invitation) 페이지로 이동

### 테스트 결과
#### 토큰으로 직접 참여
https://github.com/user-attachments/assets/ef3af1c8-f80f-45ce-88b3-c14901d90f10
#### 팀 초대 링크를 통해 참여
https://github.com/user-attachments/assets/8fb5cc06-7ddd-47a5-aa49-ae0efcd4b990

### 리뷰포인트
- 현재 초대 링크가 localhost 기준이라 배포 후 변경하겠습니다.
- 팀 참여 링크나 토큰 모두 서비스 외 방법(이메일, sns 등)으로 전달해야 합니다. 제 생각으로는 이런 상황에서 토큰을 전달할 필요가 없을 것 같아서 확인해보시고 논의하면 좋을 것 같습니다😀