### PR TITLE
팀 생성, 수정 API 요청 중복 방지

### DIFF
--- a/src/app/(routes)/[teamid]/edit/page.tsx
+++ b/src/app/(routes)/[teamid]/edit/page.tsx
@@ -8,7 +8,7 @@ import { RootState } from '@/app/stores/store';
 import { GroupData } from '@/app/types/group';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams, useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { FieldValues } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 
@@ -17,6 +17,7 @@ function Page() {
   const { teamid } = useParams();
   const queryClient = useQueryClient();
   const { accessToken } = useSelector((state: RootState) => state.auth);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { data: groupData, isLoading } = useQuery({
     queryKey: ['group', teamid],
@@ -27,6 +28,8 @@ function Page() {
   const mutation = useMutation({
     mutationFn: async ({ profile, name }: FieldValues) => {
       let imageUrl: string | null = null;
+
+      setIsSubmitting(true);
 
       // 이미지 업로드 (선택된 경우만)
       if (profile && profile[0] instanceof File) {
@@ -51,6 +54,7 @@ function Page() {
     },
     onError: () => {
       alert('팀 수정에 실패했습니다.');
+      setIsSubmitting(true);
     },
   });
 
@@ -79,6 +83,7 @@ function Page() {
           initialImage={groupData?.image ?? undefined}
           initialName={groupData?.name}
           onSubmit={mutation.mutate}
+          isLoading={isSubmitting}
         >
           수정하기
         </TeamForm>

--- a/src/app/(routes)/addteam/page.tsx
+++ b/src/app/(routes)/addteam/page.tsx
@@ -7,12 +7,16 @@ import { GroupData } from '@/app/types/group';
 import TeamForm from '@/app/components/team/TeamForm';
 import { useRouter } from 'next/navigation';
 import useRedirectLogin from '@/app/hooks/useRedirectLogin';
+import { useState } from 'react';
 
 function Page() {
   const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const onSubmit = async ({ profile, name }: FieldValues) => {
     let imageUrl: string | null = null;
+
+    setIsSubmitting(true);
 
     /**
      * 이미지 업로드
@@ -49,6 +53,7 @@ function Page() {
       router.push(`/${id}`);
     } catch (error) {
       alert('팀 생성에 실패했습니다.');
+      setIsSubmitting(false);
     }
   };
 
@@ -60,7 +65,9 @@ function Page() {
         <h2 className="mb-6 text-center text-2xl font-medium text-text-primary tablet:mb-20">
           팀 생성하기
         </h2>
-        <TeamForm onSubmit={onSubmit}>생성하기</TeamForm>
+        <TeamForm onSubmit={onSubmit} isLoading={isSubmitting}>
+          생성하기
+        </TeamForm>
         <div className="mt-6 text-center text-md text-text-primary tablet:text-lg">
           팀 이름은 회사명이나 모임 이름 등으로 설정하면 좋아요.
         </div>

--- a/src/app/components/team/TeamForm.tsx
+++ b/src/app/components/team/TeamForm.tsx
@@ -8,6 +8,7 @@ interface TeamFormProps {
   initialImage?: string;
   initialName?: string;
   onSubmit: (data: FieldValues) => void;
+  isLoading: boolean;
 }
 
 function TeamForm({
@@ -15,6 +16,7 @@ function TeamForm({
   initialImage,
   initialName,
   onSubmit,
+  isLoading,
 }: PropsWithChildren<TeamFormProps>) {
   const method = useForm<FieldValues>({
     defaultValues: { image: initialImage, name: initialName },
@@ -55,6 +57,7 @@ function TeamForm({
         variant="primary"
         className="mt-10 w-full text-white"
         onClick={handleSubmit(onSubmit)}
+        disabled={isLoading}
       >
         {children}
       </Button>


### PR DESCRIPTION
### 이슈 번호

#28 

### 변경 사항 요약
- 팀 생성, 수정 api 요청 중 버튼 비활성화
- api 요청 실패 시 버튼 활성화

### 테스트 결과


https://github.com/user-attachments/assets/e77904f4-a4e0-4450-99c7-9d507f9c2a80


https://github.com/user-attachments/assets/facc8ff0-5574-4a36-8c04-dd000e5c3585



### 리뷰포인트
