### PR TITLE
팀 리스트 페이지 할 일 카드 Drag&Drop 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "coworkers",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
         "@reduxjs/toolkit": "^2.5.1",
         "@tanstack/react-query": "^5.66.0",
         "axios": "^1.7.9",
@@ -68,6 +71,73 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
     "@reduxjs/toolkit": "^2.5.1",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.7.9",

--- a/src/app/(routes)/[teamid]/[tasklist]/page.tsx
+++ b/src/app/(routes)/[teamid]/[tasklist]/page.tsx
@@ -32,7 +32,7 @@ function TaskListPage() {
   if (isLoading) return <div>Loading...</div>;
 
   return (
-    <div className="mx-auto mt-24 flex w-full max-w-[75rem] flex-col gap-6 px-3.5 tablet:px-6">
+    <div className="mx-auto my-24 flex w-full max-w-[75rem] flex-col gap-6 px-3.5 tablet:px-6">
       <p className="text-xl">할 일</p>
       <div className="flex justify-between">
         <DatePicker

--- a/src/app/(routes)/[teamid]/[tasklist]/page.tsx
+++ b/src/app/(routes)/[teamid]/[tasklist]/page.tsx
@@ -32,7 +32,7 @@ function TaskListPage() {
   if (isLoading) return <div>Loading...</div>;
 
   return (
-    <div className="mx-auto my-24 flex w-full max-w-[75rem] flex-col gap-6 px-3.5 tablet:px-6">
+    <div className="mx-auto mt-24 flex w-full max-w-[75rem] flex-col gap-6 px-3.5 tablet:px-6">
       <p className="text-xl">할 일</p>
       <div className="flex justify-between">
         <DatePicker

--- a/src/app/components/taskdetail/TaskCommentCard.tsx
+++ b/src/app/components/taskdetail/TaskCommentCard.tsx
@@ -3,6 +3,8 @@ import { getTimeDifference } from '@/app/utils/formatTime';
 import { Dispatch, SetStateAction, useState } from 'react';
 import { useEditTaskCommentMutation } from '@/app/lib/comment/patchComment';
 import Image from 'next/image';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/app/stores/store';
 import TaskDetailProfile from '../icons/TaskDetailProfile';
 import TaskCommentMenu from './TaskCommentDropdown';
 import Button from '../common/button/Button';
@@ -23,6 +25,8 @@ function TaskCommentCard({
   const [currentComment, setCurrentComment] = useState(comment.content);
 
   const editCommentMutation = useEditTaskCommentMutation();
+  const { user } = useSelector((state: RootState) => state.auth);
+  const isUserComment = comment.user.id === Number(user?.id);
 
   const handleEditClick = () => {
     setIsEditing(true);
@@ -72,12 +76,16 @@ function TaskCommentCard({
           <>
             <div className="flex items-center justify-between">
               <p className="text-md text-text-primary">{currentComment}</p>
-              <TaskCommentMenu
-                taskId={taskId}
-                commentId={comment.id}
-                onEdit={handleEditClick}
-                setIsModalOpen={setIsModalOpen}
-              />
+              <div className="min-h-[1.64rem]">
+                {isUserComment && (
+                  <TaskCommentMenu
+                    taskId={taskId}
+                    commentId={comment.id}
+                    onEdit={handleEditClick}
+                    setIsModalOpen={setIsModalOpen}
+                  />
+                )}
+              </div>
             </div>
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">

--- a/src/app/components/tasklist/SortableTaskCard.tsx
+++ b/src/app/components/tasklist/SortableTaskCard.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useSortable } from '@dnd-kit/sortable'; // 개별 요소 드래그 훅
+import { CSS } from '@dnd-kit/utilities';
+import TaskCard from '@/app/components/tasklist/TaskCard';
+import { Task } from '@/app/types/task';
+
+interface SortableTaskCardProps {
+  task: Task;
+  groupId: number;
+  taskListId: number;
+}
+
+export default function SortableTaskCard({
+  task,
+  groupId,
+  taskListId,
+}: SortableTaskCardProps) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({
+      id: task.id,
+      transition: {
+        duration: 150,
+        easing: 'ease-in-out',
+      },
+    });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners} // 드래그 이벤트 감지
+      className="relative cursor-grab active:cursor-grabbing"
+    >
+      <TaskCard teamId={groupId} taskListId={taskListId} taskId={task.id} />
+    </div>
+  );
+}

--- a/src/app/components/tasklist/SortableTaskCard.tsx
+++ b/src/app/components/tasklist/SortableTaskCard.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useSortable } from '@dnd-kit/sortable'; // 개별 요소 드래그 훅
-import { CSS } from '@dnd-kit/utilities';
 import TaskCard from '@/app/components/tasklist/TaskCard';
 import { Task } from '@/app/types/task';
+import clsx from 'clsx';
 
 interface SortableTaskCardProps {
   task: Task;
@@ -16,18 +16,28 @@ export default function SortableTaskCard({
   groupId,
   taskListId,
 }: SortableTaskCardProps) {
-  const { attributes, listeners, setNodeRef, transform, transition } =
-    useSortable({
-      id: task.id,
-      transition: {
-        duration: 150,
-        easing: 'ease-in-out',
-      },
-    });
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: task.id,
+    transition: {
+      duration: 150,
+      easing: 'ease-in-out',
+    },
+  });
 
   const style = {
-    transform: CSS.Transform.toString(transform),
+    transform: transform
+      ? `translate3d(${transform.x}px, ${transform.y}px, 0)`
+      : 'none',
     transition,
+    zIndex: isDragging ? 10 : 'auto',
+    opacity: isDragging ? 0.8 : 1,
   };
 
   return (
@@ -36,7 +46,9 @@ export default function SortableTaskCard({
       style={style}
       {...attributes}
       {...listeners} // 드래그 이벤트 감지
-      className="relative cursor-grab active:cursor-grabbing"
+      className={clsx('relative cursor-grab active:cursor-grabbing', {
+        'pointer-events-none': isDragging,
+      })}
     >
       <TaskCard teamId={groupId} taskListId={taskListId} taskId={task.id} />
     </div>

--- a/src/app/components/tasklist/TaskCardList.tsx
+++ b/src/app/components/tasklist/TaskCardList.tsx
@@ -44,6 +44,16 @@ function TaskCardList({
     }
   }, [data, dispatch]);
 
+  useEffect(() => {
+    if (isDrawerOpen) {
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isDrawerOpen]);
+
   const openDrawer = (taskid: number) => {
     setSelectedTaskId(taskid);
     setIsDrawerOpen(true);
@@ -123,7 +133,7 @@ function TaskCardList({
         items={tasksState.map((task) => task.id)}
         strategy={verticalListSortingStrategy} // 세로 방향 정렬
       >
-        <div className="flex flex-col gap-6 overflow-hidden">
+        <div className="flex flex-col gap-6 overflow-hidden pb-24">
           <div className="flex flex-col gap-4">
             {tasksState.map((task) => (
               <div

--- a/src/app/components/tasklist/TaskCardList.tsx
+++ b/src/app/components/tasklist/TaskCardList.tsx
@@ -1,12 +1,24 @@
 'use client';
 
-import TaskCard from '@/app/components/tasklist/TaskCard';
+import { useState, useEffect } from 'react';
+import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import { useTasksQuery } from '@/app/lib/task/getTask';
-import { useAppDispatch, useAppSelector } from '@/app/stores/hooks';
-import selectTasksArray from '@/app/stores/selectors';
+import { useAppDispatch } from '@/app/stores/hooks';
 import { setTasks } from '@/app/stores/tasksSlice';
-import { useEffect, useState } from 'react';
 import TaskDetailDrawer from '../taskdetail/TaskDetailDrawer';
+import SortableTaskCard from './SortableTaskCard';
 
 function TaskCardList({
   groupId,
@@ -19,14 +31,13 @@ function TaskCardList({
 }) {
   const dispatch = useAppDispatch();
   const { data, isLoading, error } = useTasksQuery(groupId, taskListId, date);
-
-  const tasks = useAppSelector(selectTasksArray);
-
+  const [tasksState, setTasksState] = useState(data || []);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
 
   useEffect(() => {
     if (data) {
+      setTasksState(data);
       dispatch(setTasks(data));
     }
   }, [data, dispatch]);
@@ -48,12 +59,34 @@ function TaskCardList({
     ) {
       return;
     }
-
     if (e.key === 'Enter' || e.key === ' ') {
       openDrawer(taskId);
       e.preventDefault();
     }
   };
+
+  // 드래그가 끝나면 호출되는 함수
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = tasksState.findIndex((task) => task.id === active.id);
+    const newIndex = tasksState.findIndex((task) => task.id === over.id);
+
+    if (oldIndex !== -1 && newIndex !== -1) {
+      const newTasks = arrayMove(tasksState, oldIndex, newIndex);
+      setTasksState(newTasks);
+    }
+  };
+
+  // 드래그 센서: 10px 이상 이동하면 드래그로 감지
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 10,
+      },
+    }),
+  );
 
   if (isLoading) {
     return <div>로딩 중입니다</div>;
@@ -63,43 +96,55 @@ function TaskCardList({
     return <div>error</div>;
   }
 
-  if (!tasks || tasks.length === 0) {
+  if (!tasksState || tasksState.length === 0) {
     return (
       <div className="mt-[11.9375rem] flex h-screen justify-center text-md text-text-default tablet:mt-[21.5625rem] lg:mt-[19.375rem]">
         아직 할 일이 없습니다. <br /> 할 일을 추가해보세요.
       </div>
     );
   }
+
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-4">
-        {tasks.map((task) => (
-          <div
-            key={task.id}
-            role="button"
-            tabIndex={0}
-            onClick={() => openDrawer(task.id)}
-            onKeyDown={(e) => handleKeyDown(e, task.id)}
-            className="cursor-pointer rounded-[0.5rem] border border-transparent transition-all duration-200 ease-in-out hover:border-background-inverse"
-          >
-            <TaskCard
-              teamId={groupId}
-              taskListId={taskListId}
-              taskId={task.id}
-            />
+    <DndContext
+      collisionDetection={closestCenter}
+      sensors={sensors}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext // 정렬 가능한 아이템 포함하는 컨텍스트
+        items={tasksState.map((task) => task.id)}
+        strategy={verticalListSortingStrategy} // 세로 방향 정렬
+      >
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-4">
+            {tasksState.map((task) => (
+              <div
+                key={task.id}
+                role="button"
+                tabIndex={0}
+                onClick={() => openDrawer(task.id)}
+                onKeyDown={(e) => handleKeyDown(e, task.id)}
+                className="cursor-pointer rounded-[0.5rem] border border-transparent transition-all duration-200 ease-in-out hover:border-background-inverse"
+              >
+                <SortableTaskCard
+                  task={task}
+                  groupId={groupId}
+                  taskListId={taskListId}
+                />
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
-      {isDrawerOpen && selectedTaskId !== null && (
-        <TaskDetailDrawer
-          isOpen={isDrawerOpen}
-          onClose={closeDrawer}
-          groupId={groupId}
-          taskListId={taskListId}
-          taskId={selectedTaskId}
-        />
-      )}
-    </div>
+          {isDrawerOpen && selectedTaskId !== null && (
+            <TaskDetailDrawer
+              isOpen={isDrawerOpen}
+              onClose={closeDrawer}
+              groupId={groupId}
+              taskListId={taskListId}
+              taskId={selectedTaskId}
+            />
+          )}
+        </div>
+      </SortableContext>
+    </DndContext>
   );
 }
 

--- a/src/app/components/tasklist/TaskCardList.tsx
+++ b/src/app/components/tasklist/TaskCardList.tsx
@@ -17,6 +17,7 @@ import {
 import { useTasksQuery } from '@/app/lib/task/getTask';
 import { useAppDispatch } from '@/app/stores/hooks';
 import { setTasks } from '@/app/stores/tasksSlice';
+import { useEditTaskOrderMutation } from '@/app/lib/task/patchTask';
 import TaskDetailDrawer from '../taskdetail/TaskDetailDrawer';
 import SortableTaskCard from './SortableTaskCard';
 
@@ -31,6 +32,7 @@ function TaskCardList({
 }) {
   const dispatch = useAppDispatch();
   const { data, isLoading, error } = useTasksQuery(groupId, taskListId, date);
+  const { mutate: editTaskOrderMutation } = useEditTaskOrderMutation();
   const [tasksState, setTasksState] = useState(data || []);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
@@ -76,6 +78,13 @@ function TaskCardList({
     if (oldIndex !== -1 && newIndex !== -1) {
       const newTasks = arrayMove(tasksState, oldIndex, newIndex);
       setTasksState(newTasks);
+
+      editTaskOrderMutation({
+        groupId,
+        taskListId,
+        id: Number(active.id),
+        displayIndex: newIndex,
+      });
     }
   };
 

--- a/src/app/components/tasklist/TaskCardList.tsx
+++ b/src/app/components/tasklist/TaskCardList.tsx
@@ -123,7 +123,7 @@ function TaskCardList({
         items={tasksState.map((task) => task.id)}
         strategy={verticalListSortingStrategy} // 세로 방향 정렬
       >
-        <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-6 overflow-hidden">
           <div className="flex flex-col gap-4">
             {tasksState.map((task) => (
               <div

--- a/src/app/lib/task/patchTask.ts
+++ b/src/app/lib/task/patchTask.ts
@@ -59,3 +59,9 @@ export const editTaskOrder = async ({
 
   return res.data;
 };
+
+export const useEditTaskOrderMutation = () => {
+  return useMutation({
+    mutationFn: editTaskOrder,
+  });
+};


### PR DESCRIPTION
### 이슈 번호

close #88 

### 변경 사항 요약
- 팀 리스트 페이지 할 일 카드 Drag&Drop 구현
  - [x] `dnd-kit` 패키지 설치
  - [x] UI/애니메이션 구현
  - [x] 업데이트 API 연결(테스트 완료)
  - [x] 창모드일 때,  `할 일 추가` 버튼에 의해 마지막 카드 `드롭다운`이 가려지는 부분 수정
 
### 테스트 결과

https://github.com/user-attachments/assets/df6768bf-1c21-41a6-87f2-73c42a2ce7b4


### 리뷰포인트
- `dnd-kit` 패키지 설치 했으니 npm i 해주시면 감사하겠습니다.
- 기존 `TaskCard`를 재사용하여 `SortableTaskCard` 컴포넌트를 만들어 정렬 및 드래그 가능하도록 만들었습니다.
- 드래그 아이템은 다른 요소들 대비 z-index를 높이고 투명도를 주었습니다. (스타일 피드백 적극 수용합니다!😄)
- 카드가 드래그 할 수 있는 요소임을 알리는 스타일을 넣고 싶었는데 좋은 아이디어가 안 떠올라 일단 마우스 커서가 변경되게 해두었습니다. (카드 자체가 원래 클릭 가능한 요소라 커서가 바뀌어도 티가 잘 안나네요😭)