### PR TITLE
공통 모달 닫기(x) 버튼 Default로 수정

### DIFF
--- a/src/app/components/common/modal/Modal.tsx
+++ b/src/app/components/common/modal/Modal.tsx
@@ -69,7 +69,7 @@ function Modal({
         {hasCloseBtn && (
           <button
             type="button"
-            className="absolute right-4 top-4 h-6 w-6"
+            className="absolute right-4 top-4 h-6 w-6 transition-all duration-200 hover:scale-90 hover:opacity-85"
             title="모달 닫기"
             onClick={closeModal}
           >

--- a/src/app/components/common/modal/Modal.tsx
+++ b/src/app/components/common/modal/Modal.tsx
@@ -12,7 +12,7 @@ interface ModalProps {
 }
 
 function Modal({
-  hasCloseBtn = false,
+  hasCloseBtn = true,
   portalRoot, // Modal 렌더링할 상위 DOM 노드
   closeModal,
   isOpen,


### PR DESCRIPTION
### 이슈 번호

#17 

### 변경 사항 요약
- 모달 닫기(x) 버튼 Default로 수정
 
### 테스트 결과
![image](https://github.com/user-attachments/assets/0626fb3a-395d-46c6-bbff-c2cb0fc8d53f)
![image](https://github.com/user-attachments/assets/f870fcba-5397-468c-8e9d-cab5bf245e77)


### 리뷰포인트
- Modal 컴포넌트 hasCloseBtn prop의 default를 true로 수정했습니다.
- 혹시 닫기 버튼이 노출 안되시는 경우는 hasClsoeBtn prop을 false로 설정하셨는지 확인 부탁 드립니다.
- 테스트 후 머지하겠습니다.