### PR TITLE
할 일 리스트/할 일 상세 페이지 오류 및 스타일 수정

### DIFF
--- a/src/app/(routes)/[teamid]/[tasklist]/page.tsx
+++ b/src/app/(routes)/[teamid]/[tasklist]/page.tsx
@@ -84,12 +84,15 @@ function TaskListPage() {
       >
         + 할 일 추가
       </Button>
-      {isOpen && modalType === 'list' && (
-        <CreateListModal onClose={closeModal} groupId={Number(teamid)} />
-      )}
-      {isOpen && modalType === 'task' && (
-        <CreateTaskModal onClose={closeModal} />
-      )}
+      <CreateListModal
+        isOpen={isOpen && modalType === 'list'}
+        onClose={closeModal}
+        groupId={Number(teamid)}
+      />
+      <CreateTaskModal
+        isOpen={isOpen && modalType === 'task'}
+        onClose={closeModal}
+      />
     </div>
   );
 }

--- a/src/app/components/taskdetail/TaskCommentCard.tsx
+++ b/src/app/components/taskdetail/TaskCommentCard.tsx
@@ -67,7 +67,12 @@ function TaskCommentCard({
               <Button onClick={handleCancelClick} variant="cancel" size="small">
                 취소
               </Button>
-              <Button onClick={handleSaveClick} variant="complete" size="small">
+              <Button
+                onClick={handleSaveClick}
+                variant="complete"
+                size="small"
+                disabled={editedComment.trim() === ''}
+              >
                 수정
               </Button>
             </div>

--- a/src/app/components/taskdetail/TaskDetail.tsx
+++ b/src/app/components/taskdetail/TaskDetail.tsx
@@ -1,3 +1,4 @@
+import { motion } from 'framer-motion';
 import { useTaskQuery } from '@/app/lib/task/getTask';
 import { formatDateShort } from '@/app/utils/formatDate';
 import { useQueryClient } from '@tanstack/react-query';
@@ -232,15 +233,31 @@ function TaskDetail({
             </p>
           )}
           <TaskComments taskId={taskId} setIsModalOpen={setIsModalOpen} />
-          <Button
-            variant={doneAt ? 'cancel' : 'complete'}
-            size={doneAt ? 'cancel' : 'complete'}
+          <motion.div
+            initial={{ opacity: 0, y: 50 }}
+            animate={{
+              opacity: 1,
+              y: 0,
+              transition: { duration: 0.7, ease: 'easeOut' },
+            }}
+            exit={{
+              opacity: 0,
+              transition: {
+                opacity: { duration: 0, ease: 'easeIn' },
+                ease: 'easeIn',
+              },
+            }}
             className="fixed bottom-6 right-4 tablet:bottom-5 tablet:right-6 xl:bottom-10 xl:right-10"
-            onClick={toggleDone}
           >
-            <IconCheck />
-            {doneAt ? '완료 취소하기' : '완료하기'}
-          </Button>
+            <Button
+              variant={doneAt ? 'cancel' : 'complete'}
+              size={doneAt ? 'cancel' : 'complete'}
+              onClick={toggleDone}
+            >
+              <IconCheck />
+              {doneAt ? '완료 취소하기' : '완료하기'}
+            </Button>
+          </motion.div>
         </div>
       </div>
     </FormProvider>

--- a/src/app/components/taskdetail/TaskDetailDropdown.tsx
+++ b/src/app/components/taskdetail/TaskDetailDropdown.tsx
@@ -1,6 +1,7 @@
 import useDropdown from '@/app/hooks/useDropdown';
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { useAppSelector } from '@/app/stores/hooks';
+import useModal from '@/app/hooks/useModal';
 import Dropdown from '../common/dropdown/Dropdown';
 import DropdownItem from '../common/dropdown/DropdownItem';
 import DropdownList from '../common/dropdown/DropdownList';
@@ -25,13 +26,9 @@ export default function TaskDetailDropdown({
   onEdit: () => void;
 }) {
   const task = useAppSelector((state) => state.tasks.taskById[taskId]);
-  const [modalState, setModalState] = useState<{
-    isOpen: boolean;
-    type: 'deleteTask' | 'deleteRecurring' | null;
-  }>({
-    isOpen: false,
-    type: null,
-  });
+
+  const deleteTaskModal = useModal();
+  const deleteRecurringModal = useModal();
 
   const {
     isOpen: isDropdownOpen,
@@ -40,16 +37,6 @@ export default function TaskDetailDropdown({
   } = useDropdown();
 
   if (!task) return null;
-
-  const openModal = (type: 'deleteTask' | 'deleteRecurring') => {
-    setModalState({ isOpen: true, type });
-    setIsModalOpen(true);
-  };
-
-  const closeModal = () => {
-    setModalState({ isOpen: false, type: null });
-    setIsModalOpen(false);
-  };
 
   return (
     <>
@@ -74,8 +61,9 @@ export default function TaskDetailDropdown({
           <DropdownItem
             className="text-sm"
             onClick={() => {
+              deleteTaskModal.openModal();
+              setIsModalOpen(true);
               closeDropdown();
-              openModal('deleteTask');
             }}
           >
             단일 삭제하기
@@ -83,8 +71,9 @@ export default function TaskDetailDropdown({
           <DropdownItem
             className="text-sm"
             onClick={() => {
+              deleteRecurringModal.openModal();
+              setIsModalOpen(true);
               closeDropdown();
-              openModal('deleteRecurring');
             }}
           >
             반복 삭제하기
@@ -92,29 +81,29 @@ export default function TaskDetailDropdown({
         </DropdownList>
       </Dropdown>
 
-      {modalState.isOpen && modalState.type === 'deleteTask' && (
-        <DeleteTaskModal
-          isOpen={modalState.isOpen}
-          onClose={closeModal}
-          onDeleteSuccess={() => {
-            onDeleteSuccess();
-          }}
-          groupId={groupId}
-          taskListId={taskListId}
-          taskId={taskId}
-        />
-      )}
+      <DeleteTaskModal
+        isOpen={deleteTaskModal.isOpen}
+        onClose={() => {
+          deleteTaskModal.closeModal();
+          setIsModalOpen(false);
+        }}
+        onDeleteSuccess={onDeleteSuccess}
+        groupId={groupId}
+        taskListId={taskListId}
+        taskId={taskId}
+      />
 
-      {modalState.isOpen && modalState.type === 'deleteRecurring' && (
-        <DeleteRecurringModal
-          isOpen={modalState.isOpen}
-          onClose={closeModal}
-          onDeleteSuccess={onDeleteSuccess}
-          groupId={groupId}
-          taskListId={taskListId}
-          taskId={taskId}
-        />
-      )}
+      <DeleteRecurringModal
+        isOpen={deleteRecurringModal.isOpen}
+        onClose={() => {
+          deleteRecurringModal.closeModal();
+          setIsModalOpen(false);
+        }}
+        onDeleteSuccess={onDeleteSuccess}
+        groupId={groupId}
+        taskListId={taskListId}
+        taskId={taskId}
+      />
     </>
   );
 }

--- a/src/app/components/tasklist/CreateListModal.tsx
+++ b/src/app/components/tasklist/CreateListModal.tsx
@@ -7,6 +7,7 @@ import {
   useCreateTaskListMutation,
 } from '@/app/lib/tasklist/postTaskList';
 import { AxiosError } from 'axios';
+import { useEffect } from 'react';
 import Modal from '../common/modal/Modal';
 import Button from '../common/button/Button';
 import Input from '../common/input/Input';
@@ -23,9 +24,15 @@ export default function CreateListModal({
   groupId,
 }: CreateListModalProps) {
   const method = useForm<PostTaskListRequest>();
-  const { setError } = method;
+  const { setError, reset } = method;
   const queryClient = useQueryClient();
   const { mutate, isPending } = useCreateTaskListMutation();
+
+  useEffect(() => {
+    if (isOpen) {
+      reset();
+    }
+  }, [isOpen, reset]);
 
   const handleSubmit = method.handleSubmit((data) => {
     mutate(
@@ -68,10 +75,14 @@ export default function CreateListModal({
                 name="name"
                 title="목록 이름"
                 type="text"
-                placeholder="목록 이름을 입력해주세요."
+                placeholder="할 일 목록을 입력해주세요."
                 autoComplete="off"
                 validationRules={{
-                  required: '목록 이름을 입력해주세요.',
+                  required: '할 일 목록을 입력해주세요.',
+                  maxLength: {
+                    value: 30,
+                    message: '할 일 목록은 최대 30글자까지 입력 가능합니다.',
+                  },
                   validate: (value) =>
                     value.trim() !== '' ||
                     '할 일 목록은 공백만 입력할 수 없습니다.',

--- a/src/app/components/tasklist/CreateListModal.tsx
+++ b/src/app/components/tasklist/CreateListModal.tsx
@@ -11,11 +11,13 @@ import Button from '../common/button/Button';
 import Input from '../common/input/Input';
 
 interface CreateListModalProps {
+  isOpen: boolean;
   onClose: () => void;
   groupId: number;
 }
 
 export default function CreateListModal({
+  isOpen,
   onClose,
   groupId,
 }: CreateListModalProps) {
@@ -42,7 +44,7 @@ export default function CreateListModal({
 
   return (
     <>
-      <Modal isOpen closeModal={onClose}>
+      <Modal isOpen={isOpen} closeModal={onClose}>
         <div className="mb-4 flex w-[17.5rem] w-full flex-col gap-4 text-center">
           <p className="text-lg font-medium">새로운 목록 추가</p>
           <p className="text-md text-text-secondary">

--- a/src/app/components/tasklist/CreateTaskModal.tsx
+++ b/src/app/components/tasklist/CreateTaskModal.tsx
@@ -15,10 +15,14 @@ import RepeatSelector from './RepeatSelector';
 import DateTimeSelector from './DateTimeSeletor';
 
 interface CreateTaskModalProps {
+  isOpen: boolean;
   onClose: () => void;
 }
 
-export default function CreateTaskModal({ onClose }: CreateTaskModalProps) {
+export default function CreateTaskModal({
+  onClose,
+  isOpen,
+}: CreateTaskModalProps) {
   const params = useParams();
   const { teamid: groupId, tasklist: taskListId, date: selectedDate } = params;
   const [selectedTime, setSelectedTime] = useState('');
@@ -93,7 +97,7 @@ export default function CreateTaskModal({ onClose }: CreateTaskModalProps) {
 
   return (
     <>
-      <Modal isOpen closeModal={handleClose}>
+      <Modal isOpen={isOpen} closeModal={handleClose}>
         <div className="custom-scrollbar flex flex-col items-center gap-6 overflow-y-scroll px-2">
           <div className="flex w-full flex-col gap-4 text-center">
             <p className="text-lg font-medium">할 일 만들기</p>

--- a/src/app/components/tasklist/DeleteRecurringModal.tsx
+++ b/src/app/components/tasklist/DeleteRecurringModal.tsx
@@ -59,6 +59,7 @@ export default function DeleteRecurringModal({
           e.preventDefault();
         }
       }}
+      className={`${isOpen ? 'block' : 'hidden'}`}
     >
       <Modal isOpen={isOpen} closeModal={onClose}>
         <div className="flex flex-col items-center gap-2 text-center">

--- a/src/app/components/tasklist/DeleteTaskModal.tsx
+++ b/src/app/components/tasklist/DeleteTaskModal.tsx
@@ -51,6 +51,7 @@ export default function DeleteTaskModal({
           e.preventDefault();
         }
       }}
+      className={`${isOpen ? 'block' : 'hidden'}`}
     >
       <Modal isOpen={isOpen} closeModal={onClose}>
         <div className="flex flex-col items-center gap-2 text-center">

--- a/src/app/components/tasklist/EditTaskModal.tsx
+++ b/src/app/components/tasklist/EditTaskModal.tsx
@@ -84,6 +84,7 @@ export default function EditTaskModal({
           e.preventDefault();
         }
       }}
+      className={`${isOpen ? 'block' : 'hidden'}`}
     >
       <Modal isOpen={isOpen} closeModal={onClose}>
         <div className="flex flex-col gap-4">

--- a/src/app/components/tasklist/TaskCardDropdown.tsx
+++ b/src/app/components/tasklist/TaskCardDropdown.tsx
@@ -1,6 +1,6 @@
 import useDropdown from '@/app/hooks/useDropdown';
-import { useState } from 'react';
 import { useAppSelector } from '@/app/stores/hooks';
+import useModal from '@/app/hooks/useModal';
 import Dropdown from '../common/dropdown/Dropdown';
 import DropdownItem from '../common/dropdown/DropdownItem';
 import DropdownList from '../common/dropdown/DropdownList';
@@ -22,13 +22,11 @@ export default function TaskCardDropdown({
   taskId,
 }: TaskCardDropdownInterface) {
   const task = useAppSelector((state) => state.tasks.taskById[taskId]);
-  const [modalState, setModalState] = useState<{
-    isOpen: boolean;
-    type: 'deleteTask' | 'deleteRecurring' | 'editTask' | null;
-  }>({
-    isOpen: false,
-    type: null,
-  });
+
+  const editTaskModal = useModal();
+  const deleteTaskModal = useModal();
+  const deleteRecurringModal = useModal();
+
   const {
     isOpen: isDropdownOpen,
     toggleDropdown,
@@ -36,14 +34,6 @@ export default function TaskCardDropdown({
   } = useDropdown();
 
   if (!task) return null;
-
-  const openModal = (type: 'editTask' | 'deleteTask' | 'deleteRecurring') => {
-    setModalState({ isOpen: true, type });
-  };
-
-  const closeModal = () => {
-    setModalState({ isOpen: false, type: null });
-  };
 
   return (
     <>
@@ -58,8 +48,8 @@ export default function TaskCardDropdown({
           <DropdownItem
             className="text-sm"
             onClick={() => {
+              editTaskModal.openModal();
               closeDropdown();
-              openModal('editTask');
             }}
           >
             수정하기
@@ -67,8 +57,8 @@ export default function TaskCardDropdown({
           <DropdownItem
             className="text-sm"
             onClick={() => {
+              deleteTaskModal.openModal();
               closeDropdown();
-              openModal('deleteTask');
             }}
           >
             단일 삭제하기
@@ -76,8 +66,8 @@ export default function TaskCardDropdown({
           <DropdownItem
             className="text-sm"
             onClick={() => {
+              deleteRecurringModal.openModal();
               closeDropdown();
-              openModal('deleteRecurring');
             }}
           >
             반복 삭제하기
@@ -85,35 +75,29 @@ export default function TaskCardDropdown({
         </DropdownList>
       </Dropdown>
 
-      {modalState.isOpen && modalState.type === 'editTask' && (
-        <EditTaskModal
-          isOpen={modalState.isOpen}
-          onClose={closeModal}
-          groupId={groupId}
-          taskListId={taskListId}
-          taskId={taskId}
-        />
-      )}
+      <EditTaskModal
+        isOpen={editTaskModal.isOpen}
+        onClose={editTaskModal.closeModal}
+        groupId={groupId}
+        taskListId={taskListId}
+        taskId={taskId}
+      />
 
-      {modalState.isOpen && modalState.type === 'deleteTask' && (
-        <DeleteTaskModal
-          isOpen={modalState.isOpen}
-          onClose={closeModal}
-          groupId={groupId}
-          taskListId={taskListId}
-          taskId={taskId}
-        />
-      )}
+      <DeleteTaskModal
+        isOpen={deleteTaskModal.isOpen}
+        onClose={deleteTaskModal.closeModal}
+        groupId={groupId}
+        taskListId={taskListId}
+        taskId={taskId}
+      />
 
-      {modalState.isOpen && modalState.type === 'deleteRecurring' && (
-        <DeleteRecurringModal
-          isOpen={modalState.isOpen}
-          onClose={closeModal}
-          groupId={groupId}
-          taskListId={taskListId}
-          taskId={taskId}
-        />
-      )}
+      <DeleteRecurringModal
+        isOpen={deleteRecurringModal.isOpen}
+        onClose={deleteRecurringModal.closeModal}
+        groupId={groupId}
+        taskListId={taskListId}
+        taskId={taskId}
+      />
     </>
   );
 }


### PR DESCRIPTION
### 이슈 번호

close #88 

### 변경 사항 요약

- #### 할 일 리스트
  - [x] 모달이 닫힐 때 애니메이션이 보이지 않는 오류 수정
  - [x] 목록 추가하기 유효성 검사(중복 값, 빈 값, 공백, 최대 글자 수) 추가 및 에러 메시지 수정
  - [x] 목록 추가하기 모달을 다시 열 때 input 값 `reset`

-  #### 할 일 상세
   - [x] 댓글 수정하기 오류 수정(빈 값 또는 공백 입력 후 수정하기를 눌렀을 때 수정되는 오류 -> 버튼 disabled 속성으로 해결)
   - [x] `완료하기`, `완료 취소하기` 버튼이 어색하게 렌더링 되던 현상 완화

### 테스트 결과
https://github.com/user-attachments/assets/e38a4e82-6238-4510-83c5-1ae0d5c8f524

https://github.com/user-attachments/assets/e1a63477-35fa-4a8f-9758-4f8053459e7b

https://github.com/user-attachments/assets/222483ff-1299-47e3-9ec7-97b7a57d4ab3

### 리뷰포인트
- `첫 번째 영상`: 할 일 리스트/상세 페이지에서 사용되는 모든 모달이 닫힐 때 애니메이션이 잘 동작하도록 수정하고 테스트 하였습니다. 
- `두 번째 영상`: 멘토링 때 말씀해 주셨던 할 일 상세의 할 일 완료하기/완료 취소하기 버튼이 어색하게 보이는 현상 수정했습니다. absolute로 배치하면 애니메이션 해결은 되나 버튼 특성상 fixed로 배치하는 게 더 좋을 것 같아 `motion.div`를 통해 서서히 나타나도록 수정하여 어색한 부분은 최대한 수정했지만 제 눈에 그렇게 자연스럽지는 않은 것 같습니다. 😭 확인 해보시고 좋은 방법 있으면 공유 부탁드립니다!
- `세 번째 영상`: 목록을 추가할 때 공백을 제외한 같은 이름(409 에러)이 있을 시 `이미 존재하는 목록입니다` 에러 메시지가 나오게 수정하였습니다. 이 밖에도 빈 값이거나 공백만 입력한 경우, 30자가 넘어갈 경우 오류 메시지가 나오도록 수정하였습니다.