### PR TITLE
메인 랜딩 페이지 1차 배포 오류 수정

### DIFF
--- a/src/app/components/landing/LandingFeatures.tsx
+++ b/src/app/components/landing/LandingFeatures.tsx
@@ -25,7 +25,7 @@ export default function LandingFeatures() {
         viewport={{ once: true, amount: 0.5 }}
         transition={{ duration: 0.7 }}
         variants={leftVariant}
-        className="shadow-custom mx-auto h-[29.1875rem] w-[21.4375rem] flex-col rounded-[2.5rem] bg-gradient-to-r from-brand-primary to-[#CEF57E] p-[0.0625rem] tablet:h-[22.125rem] tablet:w-[43.5rem] xl:h-[26.1875rem] xl:w-[62.25rem]"
+        className="mx-auto h-[29.1875rem] w-[21.4375rem] flex-col rounded-[2.5rem] bg-gradient-to-r from-brand-primary to-[#CEF57E] p-[0.0625rem] shadow-custom tablet:h-[22.125rem] tablet:w-[43.5rem] xl:h-[26.1875rem] xl:w-[62.25rem]"
       >
         <div className="flex h-full w-full flex-wrap-reverse items-start rounded-[2.5rem] bg-background-primary pl-[3.125rem] tablet:justify-center tablet:gap-[8.75rem] tablet:pl-0 xl:gap-[12.0625rem]">
           <Image
@@ -76,7 +76,7 @@ export default function LandingFeatures() {
         viewport={{ once: true, amount: 0.5 }}
         transition={{ duration: 0.7 }}
         variants={leftVariant}
-        className="bg-state-950 mx-auto flex h-[29.1875rem] w-[21.4375rem] flex-col gap-10 rounded-[2.5rem] pl-[3.125rem] tablet:h-[22.125rem] tablet:w-[43.5rem] tablet:flex-row tablet:items-start tablet:justify-center tablet:gap-[8.75rem] xl:h-[26.1875rem] xl:w-[62.25rem] xl:gap-[12.0625rem]"
+        className="mx-auto flex h-[29.1875rem] w-[21.4375rem] flex-col gap-10 rounded-[2.5rem] bg-state-950 pl-[3.125rem] tablet:h-[22.125rem] tablet:w-[43.5rem] tablet:flex-row tablet:items-start tablet:justify-center tablet:gap-[8.75rem] xl:h-[26.1875rem] xl:w-[62.25rem] xl:gap-[12.0625rem]"
       >
         <Image
           src="/contents/landing-section3.png"

--- a/src/app/components/landing/LandingFeatures.tsx
+++ b/src/app/components/landing/LandingFeatures.tsx
@@ -18,14 +18,14 @@ export default function LandingFeatures() {
   };
 
   return (
-    <div className="flex flex-col gap-6 xl:gap-20">
+    <div className="flex flex-col gap-6 overflow-x-hidden xl:gap-20">
       <motion.div
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true, amount: 0.5 }}
         transition={{ duration: 0.7 }}
         variants={leftVariant}
-        className="mx-auto h-[29.1875rem] w-[21.4375rem] flex-col rounded-[2.5rem] bg-gradient-to-r from-brand-primary to-[#CEF57E] p-[0.0625rem] shadow-custom tablet:h-[22.125rem] tablet:w-[43.5rem] xl:h-[26.1875rem] xl:w-[62.25rem]"
+        className="shadow-custom mx-auto h-[29.1875rem] w-[21.4375rem] flex-col rounded-[2.5rem] bg-gradient-to-r from-brand-primary to-[#CEF57E] p-[0.0625rem] tablet:h-[22.125rem] tablet:w-[43.5rem] xl:h-[26.1875rem] xl:w-[62.25rem]"
       >
         <div className="flex h-full w-full flex-wrap-reverse items-start rounded-[2.5rem] bg-background-primary pl-[3.125rem] tablet:justify-center tablet:gap-[8.75rem] tablet:pl-0 xl:gap-[12.0625rem]">
           <Image
@@ -76,7 +76,7 @@ export default function LandingFeatures() {
         viewport={{ once: true, amount: 0.5 }}
         transition={{ duration: 0.7 }}
         variants={leftVariant}
-        className="mx-auto flex h-[29.1875rem] w-[21.4375rem] flex-col gap-10 rounded-[2.5rem] bg-state-950 pl-[3.125rem] tablet:h-[22.125rem] tablet:w-[43.5rem] tablet:flex-row tablet:items-start tablet:justify-center tablet:gap-[8.75rem] xl:h-[26.1875rem] xl:w-[62.25rem] xl:gap-[12.0625rem]"
+        className="bg-state-950 mx-auto flex h-[29.1875rem] w-[21.4375rem] flex-col gap-10 rounded-[2.5rem] pl-[3.125rem] tablet:h-[22.125rem] tablet:w-[43.5rem] tablet:flex-row tablet:items-start tablet:justify-center tablet:gap-[8.75rem] xl:h-[26.1875rem] xl:w-[62.25rem] xl:gap-[12.0625rem]"
       >
         <Image
           src="/contents/landing-section3.png"

--- a/src/app/components/landing/LandingHeader.tsx
+++ b/src/app/components/landing/LandingHeader.tsx
@@ -60,7 +60,7 @@ export default function LandingHeader() {
       </div>
       <button
         onClick={handleStartClick}
-        className="cursor-pointer rounded-[2rem] bg-gradient-to-r from-brand-primary to-brand-tertiary px-[8.9375rem] py-3 text-base font-semibold text-white"
+        className="cursor-pointer rounded-[2rem] bg-gradient-to-r from-brand-primary to-brand-tertiary px-[8rem] py-3 text-base font-semibold text-white tablet:px-[8.9375rem]"
       >
         지금 시작하기
       </button>


### PR DESCRIPTION
### 이슈 번호

close #29 

### 변경 사항 요약

- 메인 페이지 최초 접근 시 가로 스크롤이 생기던 문제를 해결했습니다.
- Mobile 사이즈의 경우 `지금 시작하기` 버튼이 줄바꿈이 되던 문제를 해결했습니다.

### 테스트 결과

![Coworkers - Landing Page overflow적용](https://github.com/user-attachments/assets/c27e8446-e1cc-4821-bdf1-edc7e7060cc0)



