### PR TITLE
이미지 업로드 및 멤버 관련 이슈 해결

### DIFF
--- a/src/app/(routes)/[teamid]/edit/page.tsx
+++ b/src/app/(routes)/[teamid]/edit/page.tsx
@@ -59,8 +59,8 @@ function Page() {
 
   return (
     <div>
-      <div className="mx-auto mt-[3.75rem] max-w-[23.4375rem] px-4 pt-[4.5rem] tablet:w-[28.75rem] tablet:px-0 tablet:pt-[6.25rem]">
-        <h2 className="mb-6 text-center text-2xl font-medium text-text-primary tablet:mb-20">
+      <div className="mx-auto flex h-screen max-w-[23.4375rem] flex-col justify-center px-4 tablet:w-[28.75rem] tablet:px-0">
+        <h2 className="my-6 text-center text-2xl font-medium text-text-primary tablet:mb-20">
           팀 수정하기
         </h2>
         <TeamForm

--- a/src/app/(routes)/addteam/page.tsx
+++ b/src/app/(routes)/addteam/page.tsx
@@ -45,8 +45,8 @@ function Page() {
 
   return (
     <div>
-      <div className="mx-auto mt-[3.75rem] max-w-[23.4375rem] px-4 pt-[4.5rem] tablet:w-[28.75rem] tablet:px-0 tablet:pt-[6.25rem]">
-        <h2 className="mb-6 text-center text-2xl font-medium text-text-primary tablet:mb-20">
+      <div className="mx-auto flex h-screen max-w-[23.4375rem] flex-col justify-center px-4 tablet:w-[28.75rem] tablet:px-0">
+        <h2 className="my-6 text-center text-2xl font-medium text-text-primary tablet:mb-20">
           팀 생성하기
         </h2>
         <TeamForm onSubmit={mutation.mutate} isLoading={isSubmitting}>

--- a/src/app/(routes)/invitation/page.tsx
+++ b/src/app/(routes)/invitation/page.tsx
@@ -36,8 +36,9 @@ function Page() {
 
   return (
     <div>
-      <div className="mx-auto mt-[3.75rem] max-w-[23.4375rem] px-4 pt-[4.5rem] tablet:w-[28.75rem] tablet:px-0 tablet:pt-[6.25rem]">
-        <h2 className="mb-6 text-center text-2xl font-medium text-text-primary tablet:mb-20">
+      {/* <div className="mx-auto mt-[3.75rem] max-w-[23.4375rem] px-4 pt-[4.5rem] tablet:w-[28.75rem] tablet:px-0 tablet:pt-[6.25rem]"> */}
+      <div className="mx-auto flex h-screen max-w-[23.4375rem] flex-col justify-center px-4 tablet:w-[28.75rem] tablet:px-0">
+        <h2 className="my-6 text-center text-2xl font-medium text-text-primary tablet:mb-20">
           팀 참여하기
         </h2>
         <div className="mb-3 text-lg font-medium">팀 링크</div>

--- a/src/app/components/team/DetailMemberModal.tsx
+++ b/src/app/components/team/DetailMemberModal.tsx
@@ -35,8 +35,10 @@ function DetailMemberModal({ member, isOpen, closeModal }: DetailMemberProps) {
             <IconProfileEmpty className="h-full w-full" />
           )}
         </div>
-        <div className="mb-2 text-md font-medium">{member.userName}</div>
-        <div className="mb-6 text-xs text-text-secondary">
+        <div className="mb-2 overflow-hidden text-ellipsis text-md font-medium">
+          {member.userName}
+        </div>
+        <div className="mb-6 overflow-hidden text-ellipsis text-xs text-text-secondary">
           {member.userEmail}
         </div>
         <Button className="w-full text-text-inverse" onClick={handleClick}>

--- a/src/app/components/team/DetailMemberModal.tsx
+++ b/src/app/components/team/DetailMemberModal.tsx
@@ -28,7 +28,7 @@ function DetailMemberModal({ member, isOpen, closeModal }: DetailMemberProps) {
   return (
     <Modal hasCloseBtn isOpen={isOpen} closeModal={closeModal}>
       <div className="w-full px-12 text-center">
-        <div className="relative mx-auto mb-6 h-[2.875rem] w-[2.875rem] tablet:h-[3.25rem] tablet:w-[3.25rem]">
+        <div className="relative mx-auto mb-6 h-[2.875rem] w-[2.875rem] overflow-hidden rounded-full tablet:h-[3.25rem] tablet:w-[3.25rem]">
           {member.userImage ? (
             <Image src={member.userImage} fill alt="프로필 이미지" />
           ) : (

--- a/src/app/components/team/MemberCard.tsx
+++ b/src/app/components/team/MemberCard.tsx
@@ -53,19 +53,21 @@ function MemberCard({
 
   return (
     <>
-      <div className="flex items-center justify-between gap-1.5 rounded-2xl bg-background-secondary px-4 py-3 tablet:px-6 tablet:py-5">
-        <div>
+      <div className="flex w-full items-center justify-between gap-1.5 rounded-2xl bg-background-secondary px-4 py-3 tablet:px-6 tablet:py-5">
+        <div className="w-full overflow-hidden">
           <div className="mb-1.5 flex items-center gap-2 tablet:relative tablet:mb-0.5 tablet:block tablet:pl-11">
-            <div className="relative h-6 w-6 overflow-hidden rounded-full tablet:absolute tablet:inset-0 tablet:h-8 tablet:w-8">
+            <div className="relative h-6 w-6 flex-shrink-0 overflow-hidden rounded-full tablet:absolute tablet:inset-0 tablet:h-8 tablet:w-8">
               {member.userImage ? (
                 <Image src={member.userImage} fill alt="프로필 이미지" />
               ) : (
                 <IconProfileEmpty className="h-full w-full" />
               )}
             </div>
-            <div className="text-md font-medium">{member.userName}</div>
+            <div className="w-full overflow-hidden text-ellipsis text-md font-medium">
+              {member.userName}
+            </div>
           </div>
-          <div className="text-xs text-text-secondary tablet:ml-11">
+          <div className="w-full overflow-hidden text-ellipsis text-xs text-text-secondary tablet:ml-11">
             {member.userEmail}
           </div>
         </div>

--- a/src/app/components/team/MemberCardSkeleton.tsx
+++ b/src/app/components/team/MemberCardSkeleton.tsx
@@ -5,10 +5,10 @@ function MemberCardSkeleton() {
     <div className="flex w-full items-center justify-between gap-1.5 rounded-2xl bg-background-secondary px-4 py-3 tablet:px-6 tablet:py-5">
       <div className="w-full overflow-hidden">
         <div className="mb-1.5 flex items-center gap-2 tablet:relative tablet:mb-0.5 tablet:block tablet:pl-11">
-          <div className="h-6 w-6 flex-shrink-0 rounded-full bg-background-tertiary tablet:absolute tablet:inset-0 tablet:h-8 tablet:w-8" />
-          <div className="h-4 w-full rounded-sm bg-background-tertiary" />
+          <div className="h-6 w-6 flex-shrink-0 rounded-full bg-background-tertiary shinny tablet:absolute tablet:inset-0 tablet:h-8 tablet:w-8" />
+          <div className="h-4 w-full rounded-sm bg-background-tertiary shinny" />
         </div>
-        <div className="h-3.5 w-full rounded-sm bg-background-tertiary tablet:ml-11" />
+        <div className="h-3.5 w-full rounded-sm bg-background-tertiary shinny tablet:ml-11" />
       </div>
       <TaskCardDropdown />
     </div>

--- a/src/app/components/team/MemberCardSkeleton.tsx
+++ b/src/app/components/team/MemberCardSkeleton.tsx
@@ -1,0 +1,18 @@
+import TaskCardDropdown from '@/app/components/icons/TaskCardDropdown';
+
+function MemberCardSkeleton() {
+  return (
+    <div className="flex w-full items-center justify-between gap-1.5 rounded-2xl bg-background-secondary px-4 py-3 tablet:px-6 tablet:py-5">
+      <div className="w-full overflow-hidden">
+        <div className="mb-1.5 flex items-center gap-2 tablet:relative tablet:mb-0.5 tablet:block tablet:pl-11">
+          <div className="h-6 w-6 flex-shrink-0 rounded-full bg-background-tertiary tablet:absolute tablet:inset-0 tablet:h-8 tablet:w-8" />
+          <div className="h-4 w-full rounded-sm bg-background-tertiary" />
+        </div>
+        <div className="h-3.5 w-full rounded-sm bg-background-tertiary tablet:ml-11" />
+      </div>
+      <TaskCardDropdown />
+    </div>
+  );
+}
+
+export default MemberCardSkeleton;

--- a/src/app/components/team/MemberContainer.tsx
+++ b/src/app/components/team/MemberContainer.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '@/app/stores/store';
 import AddMemberModal from './AddMemberModal';
 import MemberCard from './MemberCard';
+import MemberCardSkeleton from './MemberCardSkeleton';
 
 interface GroupMember {
   role: 'ADMIN' | 'MEMBER';
@@ -32,8 +33,6 @@ function MemberContainer({ members }: { members: GroupMember[] }) {
     queryFn: () => getInvitation(members[0].groupId),
   });
 
-  if (isLoading) return <div>Loading...</div>;
-
   if (isError) return null;
 
   return (
@@ -52,9 +51,19 @@ function MemberContainer({ members }: { members: GroupMember[] }) {
         </button>
       </div>
       <div className="grid grid-cols-2 gap-4 tablet:grid-cols-3 tablet:gap-6">
-        {members.map((member) => (
-          <MemberCard key={member.userId} member={member} isAdmin={isAdmin} />
-        ))}
+        {isLoading
+          ? Array.from({ length: 6 }).map(() => (
+              <MemberCardSkeleton
+                key={`memeber_skeleton_${crypto.randomUUID()}`}
+              />
+            ))
+          : members.map((member) => (
+              <MemberCard
+                key={member.userId}
+                member={member}
+                isAdmin={isAdmin}
+              />
+            ))}
       </div>
       <AddMemberModal
         token={token || ''}

--- a/src/app/components/team/MemberContainer.tsx
+++ b/src/app/components/team/MemberContainer.tsx
@@ -52,7 +52,7 @@ function MemberContainer({ members }: { members: GroupMember[] }) {
       </div>
       <div className="grid grid-cols-2 gap-4 tablet:grid-cols-3 tablet:gap-6">
         {isLoading
-          ? Array.from({ length: 6 }).map(() => (
+          ? Array.from({ length: members.length || 6 }).map(() => (
               <MemberCardSkeleton
                 key={`memeber_skeleton_${crypto.randomUUID()}`}
               />

--- a/src/app/components/team/ProfileUploader.tsx
+++ b/src/app/components/team/ProfileUploader.tsx
@@ -2,26 +2,31 @@
 
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
-import { FieldValues, UseFormRegister } from 'react-hook-form';
+import { FieldValues, UseFormRegister, UseFormSetValue } from 'react-hook-form';
 import IconProfileEdit from '@/app/components/icons/IconProfileEdit';
 import IconProfile from '@/app/components/icons/IconProfile';
 
 interface ProfileUploaderProps {
   initialImage?: string;
   register: UseFormRegister<FieldValues>;
+  setValue: UseFormSetValue<FieldValues>;
 }
 
-function ProfileUploader({ initialImage, register }: ProfileUploaderProps) {
+function ProfileUploader({
+  initialImage,
+  register,
+  setValue,
+}: ProfileUploaderProps) {
   const [profileImage, setProfileImage] = useState<string | null>(
     initialImage || '',
   );
 
-  // 파일 처리하는 함수
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
+    if (e.target.files && e.target.files.length > 0) {
+      const file = e.target.files[0];
       const url = URL.createObjectURL(file); // 미리보기 URL 생성
-      setProfileImage(url); // 미리보기 이미지 업데이트
+      setProfileImage(url);
+      setValue('profile', file);
     }
   };
 

--- a/src/app/components/team/ProfileUploader.tsx
+++ b/src/app/components/team/ProfileUploader.tsx
@@ -2,21 +2,16 @@
 
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
-import { FieldValues, UseFormRegister, UseFormSetValue } from 'react-hook-form';
+import { FieldValues, UseFormSetValue } from 'react-hook-form';
 import IconProfileEdit from '@/app/components/icons/IconProfileEdit';
 import IconProfile from '@/app/components/icons/IconProfile';
 
 interface ProfileUploaderProps {
   initialImage?: string;
-  register: UseFormRegister<FieldValues>;
   setValue: UseFormSetValue<FieldValues>;
 }
 
-function ProfileUploader({
-  initialImage,
-  register,
-  setValue,
-}: ProfileUploaderProps) {
+function ProfileUploader({ initialImage, setValue }: ProfileUploaderProps) {
   const [profileImage, setProfileImage] = useState<string | null>(
     initialImage || '',
   );
@@ -46,7 +41,6 @@ function ProfileUploader({
           className="sr-only"
           type="file"
           accept="image/*"
-          {...register('profile')}
           onChange={handleFileChange}
         />
         {profileImage ? (

--- a/src/app/components/team/TeamForm.tsx
+++ b/src/app/components/team/TeamForm.tsx
@@ -21,7 +21,7 @@ function TeamForm({
   const method = useForm<FieldValues>({
     defaultValues: { profile: initialImage, name: initialName },
   });
-  const { register, handleSubmit, setValue } = method;
+  const { handleSubmit, setValue } = method;
 
   useEffect(() => {
     setValue('profile', initialImage);
@@ -31,11 +31,7 @@ function TeamForm({
   return (
     <FormProvider {...method}>
       <form className="flex flex-col gap-6" onSubmit={handleSubmit(onSubmit)}>
-        <ProfileUploader
-          initialImage={initialImage}
-          register={register}
-          setValue={setValue}
-        />
+        <ProfileUploader initialImage={initialImage} setValue={setValue} />
         <Input
           name="name"
           title="팀 이름"

--- a/src/app/components/team/TeamForm.tsx
+++ b/src/app/components/team/TeamForm.tsx
@@ -19,19 +19,23 @@ function TeamForm({
   isLoading,
 }: PropsWithChildren<TeamFormProps>) {
   const method = useForm<FieldValues>({
-    defaultValues: { image: initialImage, name: initialName },
+    defaultValues: { profile: initialImage, name: initialName },
   });
   const { register, handleSubmit, setValue } = method;
 
   useEffect(() => {
-    setValue('image', initialImage);
+    setValue('profile', initialImage);
     setValue('name', initialName);
   }, [initialImage, initialName, setValue]);
 
   return (
     <FormProvider {...method}>
       <form className="flex flex-col gap-6" onSubmit={handleSubmit(onSubmit)}>
-        <ProfileUploader initialImage={initialImage} register={register} />
+        <ProfileUploader
+          initialImage={initialImage}
+          register={register}
+          setValue={setValue}
+        />
         <Input
           name="name"
           title="팀 이름"

--- a/src/app/utils/uploadImage.ts
+++ b/src/app/utils/uploadImage.ts
@@ -1,10 +1,10 @@
 import postImage from '@/app/lib/image/postImage';
 
-const uploadImage = async (profile: FileList) => {
-  if (!profile || !(profile[0] instanceof File)) return null;
+const uploadImage = async (profile: File) => {
+  if (!profile || !(profile instanceof File)) return null;
 
   const formData = new FormData();
-  formData.append('image', profile[0]);
+  formData.append('image', profile);
 
   const { url } = await postImage(formData);
   return url;


### PR DESCRIPTION
### 이슈 번호
#45

### 변경 사항 요약
- nickname, email 말줄임 처리 추가
- 멤버 정보 모달 말줄임 처리 추가
- 멤버 정보 모달 프로필 이미지 round 처리 추가
- 팀 생성/수정/참가 콘텐츠 중앙 정렬
- 이미지 업로드 로직 수정 (ios 이슈 해결)
- 멤버 카드 스켈레톤 UI 추가

### 테스트 결과
#### 멤버 카드 - 말줄임
![image](https://github.com/user-attachments/assets/066e7c7d-a098-43b4-8ce0-6662ab4542db)
#### 멤버 정보 모달
![image](https://github.com/user-attachments/assets/ec1ac5b5-81f9-4552-a5b8-1612410660ef)
#### 팀 수정 ios
![image](https://github.com/user-attachments/assets/a708526f-7647-466b-8bc6-8c62776b17f5)
#### 팀 생성 ios - 결과
![image](https://github.com/user-attachments/assets/b0504c65-1514-4420-b41a-d264fa85d8c4)
#### 스켈레톤 UI 적용

https://github.com/user-attachments/assets/576e83f3-2fc1-4d08-ad95-71cd8abf7968


https://github.com/user-attachments/assets/960a163f-3cf1-44b9-9181-e33c9ed53099





### 리뷰포인트
- 아이폰 사용하시면 팀 생성, 수정에서 이미지 업로드 잘 동작하는지 확인 부탁 드립니다!
- 스켈레톤 UI는 도훈님께서 작업해주신 `shinny`로 적용해두었습니다. 디스코드 채널에 공유드린 2번이 더 괜찮다고 하시면 수정하겠습니다.