### PR TITLE
Not Found(404) 로직 추가

### DIFF
--- a/src/app/(routes)/[teamid]/[tasklist]/page.tsx
+++ b/src/app/(routes)/[teamid]/[tasklist]/page.tsx
@@ -11,6 +11,8 @@ import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import getGroupById from '@/app/lib/group/getGroupById';
 import Link from 'next/link';
+import Loading from '@/app/components/common/loading/Loading';
+import useRedirectIfNotFound from '@/app/hooks/useRedirectIfNotFound';
 
 function TaskListPage() {
   const { teamid, tasklist } = useParams();
@@ -19,7 +21,7 @@ function TaskListPage() {
   const [selectedDate, setSelectedDate] = useState<string>(
     new Date().toISOString().split('T')[0],
   );
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: ['tasklists', Number(teamid)],
     queryFn: () => getGroupById(Number(teamid)),
   });
@@ -29,7 +31,14 @@ function TaskListPage() {
     openModal();
   };
 
-  if (isLoading) return <div>Loading...</div>;
+  const isNotFound =
+    (error && error.message === 'not_found') ||
+    Number.isNaN(Number(teamid)) ||
+    Number.isNaN(Number(tasklist));
+
+  const { isRedirecting } = useRedirectIfNotFound(isNotFound);
+
+  if (isLoading || isRedirecting) return <Loading />;
 
   return (
     <div className="mx-auto mt-24 flex w-full max-w-[75rem] flex-col gap-6 px-3.5 tablet:px-6">

--- a/src/app/(routes)/[teamid]/[tasklist]/page.tsx
+++ b/src/app/(routes)/[teamid]/[tasklist]/page.tsx
@@ -39,16 +39,23 @@ function TaskListPage() {
     queryFn: () => getGroupById(Number(teamid)),
   });
 
-  const { data: taskListData, isLoading: isTaskListLoading } = useTasksQuery(
-    Number(teamid),
-    Number(tasklist),
-    selectedDate,
-  );
+  const {
+    data: taskListData,
+    isLoading: isTaskListLoading,
+    error: taskError,
+  } = useTasksQuery(Number(teamid), Number(tasklist), selectedDate);
 
-  const isLoading = isTeamLoading || (!groupData && !taskListData);
+  const handleOpenModal = (type: 'task' | 'list') => {
+    setModalType(type);
+    openModal();
+  };
+
+  const isLoading =
+    isTeamLoading || (!groupData && !taskListData) || isTaskListLoading;
 
   const isNotFound =
-    (error && error.message === 'not_found') ||
+    error?.message === 'not_found' ||
+    taskError?.message === 'not_found' ||
     Number.isNaN(Number(teamid)) ||
     Number.isNaN(Number(tasklist));
 
@@ -57,11 +64,6 @@ function TaskListPage() {
   if (isLoading || isRedirecting) return <Loading />;
 
   if (isAuthLoading) return <AuthCheckLoading />;
-
-  const handleOpenModal = (type: 'task' | 'list') => {
-    setModalType(type);
-    openModal();
-  };
 
   return (
     <div className="mx-auto mt-24 flex w-full max-w-[75rem] flex-col gap-6 px-3.5 tablet:px-6">

--- a/src/app/(routes)/[teamid]/edit/page.tsx
+++ b/src/app/(routes)/[teamid]/edit/page.tsx
@@ -11,6 +11,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams, useRouter } from 'next/navigation';
 import { FieldValues } from 'react-hook-form';
 import { useState } from 'react';
+import Loading from '@/app/components/common/loading/Loading';
+import useRedirectIfNotFound from '@/app/hooks/useRedirectIfNotFound';
 
 function Page() {
   const { isLoading: isAuthLoading } = useAuthRedirect();
@@ -21,7 +23,11 @@ function Page() {
   const queryClient = useQueryClient();
   const groupId = Number(teamid);
 
-  const { data: groupData, isLoading } = useQuery({
+  const {
+    data: groupData,
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: ['group', groupId],
     queryFn: () => getGroupById(groupId),
     enabled: !!groupId,
@@ -47,15 +53,14 @@ function Page() {
     },
   });
 
+  const isNotFound =
+    (error && error.message === 'not_found') || Number.isNaN(Number(teamid));
+
+  const { isRedirecting } = useRedirectIfNotFound(isNotFound);
+
   if (isAuthLoading) return <AuthCheckLoading />;
 
-  if (isLoading) {
-    return (
-      <div className="flex h-screen items-center justify-center text-white">
-        Loading...
-      </div>
-    );
-  }
+  if (isLoading || isRedirecting) return <Loading />;
 
   return (
     <div>

--- a/src/app/(routes)/[teamid]/page.tsx
+++ b/src/app/(routes)/[teamid]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { usePathname } from 'next/navigation';
+import { useParams, usePathname } from 'next/navigation';
 import getGroup from '@/app/lib/group/getGroup';
 import TeamHeader from '@/app/components/team/TeamHeader';
 import TodoList from '@/app/components/team/TodoList';
@@ -9,8 +9,11 @@ import Report from '@/app/components/team/Report';
 import MemberContainer from '@/app/components/team/MemberContainer';
 import useAuthRedirect from '@/app/hooks/useAuthRedirect';
 import AuthCheckLoading from '@/app/components/common/auth/AuthCheckLoading';
+import Loading from '@/app/components/common/loading/Loading';
+import useRedirectIfNotFound from '@/app/hooks/useRedirectIfNotFound';
 
 export default function TeamPage() {
+  const { teamid } = useParams();
   const { isLoading: isAuthLoading } = useAuthRedirect();
 
   const pathname = usePathname();
@@ -31,9 +34,14 @@ export default function TeamPage() {
     staleTime: 5 * 60 * 1000,
   });
 
+  const isNotFound =
+    (error && error.message === 'not_found') || Number.isNaN(Number(teamid));
+
+  const { isRedirecting } = useRedirectIfNotFound(isNotFound);
+
   if (isAuthLoading) return <AuthCheckLoading />;
 
-  if (isLoading) return <div>로딩 중...</div>;
+  if (isLoading || isRedirecting) return <Loading />;
   if (error) return <div>에러가 발생했습니다.</div>;
 
   return (

--- a/src/app/(routes)/boards/[boardid]/editboard/page.tsx
+++ b/src/app/(routes)/boards/[boardid]/editboard/page.tsx
@@ -10,6 +10,8 @@ import patchArticle, {
 import Button from '@/app/components/common/button/Button';
 import ImageChanger from '@/app/components/editboard/ImageChanger';
 import ArticleChanger from '@/app/components/editboard/ArticleChanger';
+import useRedirectIfNotFound from '@/app/hooks/useRedirectIfNotFound';
+import Loading from '@/app/components/common/loading/Loading';
 
 export default function EditBoardPage() {
   const { boardid } = useParams();
@@ -56,6 +58,14 @@ export default function EditBoardPage() {
       title,
     });
   };
+
+  const isNotFound =
+    articleQuery.error?.message === 'not_found' ||
+    Number.isNaN(Number(boardid));
+
+  const { isRedirecting } = useRedirectIfNotFound(isNotFound);
+
+  if (articleQuery.isLoading || isRedirecting) return <Loading />;
 
   return (
     <form onSubmit={handleSubmit} className="flex justify-center pt-[6.25rem]">

--- a/src/app/(routes)/boards/[boardid]/page.tsx
+++ b/src/app/(routes)/boards/[boardid]/page.tsx
@@ -8,6 +8,8 @@ import getArticleDetail, {
 
 import CommentList from '@/app/components/boarddetail/CommentList';
 import BoardDetail from '@/app/components/boarddetail/BoardDetail';
+import useRedirectIfNotFound from '@/app/hooks/useRedirectIfNotFound';
+import Loading from '@/app/components/common/loading/Loading';
 
 export default function BoardDetailPage() {
   const params = useParams();
@@ -19,15 +21,19 @@ export default function BoardDetailPage() {
     data: article,
     isLoading,
     isError,
+    error,
   } = useQuery<GetArticleDetailResponse>({
     queryKey: ['articleDetail', numericArticleId],
     queryFn: () => getArticleDetail({ articleId: numericArticleId }),
     enabled: !!articleId && !Number.isNaN(numericArticleId),
   });
 
-  if (isLoading) {
-    return <div className="pt-20 text-center">로딩 중...</div>;
-  }
+  const isNotFound =
+    error?.message === 'not_found' || Number.isNaN(numericArticleId);
+
+  const { isRedirecting } = useRedirectIfNotFound(isNotFound);
+
+  if (isLoading || isRedirecting) return <Loading />;
 
   if (isError || !article) {
     return <div className="pt-20 text-center">게시물을 찾을 수 없습니다.</div>;

--- a/src/app/components/common/loading/Loading.tsx
+++ b/src/app/components/common/loading/Loading.tsx
@@ -1,0 +1,9 @@
+function Loading() {
+  return (
+    <div className="fixed inset-0 flex h-screen items-center justify-center bg-black text-white opacity-50">
+      Loading...
+    </div>
+  );
+}
+
+export default Loading;

--- a/src/app/components/tasklist/TaskCardList.tsx
+++ b/src/app/components/tasklist/TaskCardList.tsx
@@ -18,6 +18,8 @@ import { useTasksQuery } from '@/app/lib/task/getTask';
 import { useAppDispatch } from '@/app/stores/hooks';
 import { setTasks } from '@/app/stores/tasksSlice';
 import { useEditTaskOrderMutation } from '@/app/lib/task/patchTask';
+import useRedirectIfNotFound from '@/app/hooks/useRedirectIfNotFound';
+import Loading from '@/app/components/common/loading/Loading';
 import TaskDetailDrawer from '../taskdetail/TaskDetailDrawer';
 import SortableTaskCard from './SortableTaskCard';
 
@@ -107,9 +109,11 @@ function TaskCardList({
     }),
   );
 
-  if (isLoading) {
-    return <div>로딩 중입니다</div>;
-  }
+  const { isRedirecting } = useRedirectIfNotFound(
+    error?.message === 'not_found',
+  );
+
+  if (isLoading || isRedirecting) return <Loading />;
 
   if (error) {
     return <div>error</div>;

--- a/src/app/hooks/useRedirectIfNotFound.ts
+++ b/src/app/hooks/useRedirectIfNotFound.ts
@@ -1,0 +1,18 @@
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const useRedirectIfNotFound = (isNotFound: boolean) => {
+  const router = useRouter();
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
+  useEffect(() => {
+    if (isNotFound) {
+      setIsRedirecting(true);
+      router.replace('/notfound');
+    }
+  }, [isNotFound, router]);
+
+  return { isRedirecting };
+};
+
+export default useRedirectIfNotFound;

--- a/src/app/lib/instance.ts
+++ b/src/app/lib/instance.ts
@@ -27,6 +27,9 @@ instance.interceptors.response.use(
     if (error.response?.status === 401) {
       return handleTokenRefresh(error.config);
     }
+    if (error.response?.status === 404 || error.response?.status === 500) {
+      throw new Error('not_found');
+    }
     return Promise.reject(error);
   },
 );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+function NotFound() {
+  return (
+    <div className="flex h-screen flex-col items-center justify-center">
+      <div className="relative mb-8 h-[6.125rem] w-[19.5rem] tablet:mb-12 tablet:h-[10.25rem] tablet:w-[32.5rem] xl:h-[15.9375rem] xl:w-[50.625rem]">
+        <Image
+          src="/contents/img_team_empty_desktop.png"
+          alt="소속된 팀이 없습니다."
+          fill
+        />
+      </div>
+      <div className="mb-12 text-center text-md font-medium text-text-default tablet:mb-20 tablet:text-lg xl:text-lg">
+        페이지를 찾을 수 없습니다.
+        <br />
+        팀을 생성하거나 팀에 참여해보세요.
+      </div>
+      <Link
+        href="/addteam"
+        className="mb-2 flex h-12 w-[11.625rem] items-center justify-center rounded-xl bg-brand-primary text-md font-semibold"
+      >
+        팀 생성하기
+      </Link>
+      <Link
+        href="/invitation"
+        className="flex h-12 w-[11.625rem] items-center justify-center rounded-xl border-[1px] border-brand-primary bg-transparent text-md font-semibold text-brand-primary"
+      >
+        팀 참여하기
+      </Link>
+    </div>
+  );
+}
+
+export default NotFound;

--- a/src/app/notfound/page.tsx
+++ b/src/app/notfound/page.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+function NotFound() {
+  return (
+    <div className="flex h-screen flex-col items-center justify-center">
+      <div className="relative mb-8 h-[6.125rem] w-[19.5rem] tablet:mb-12 tablet:h-[10.25rem] tablet:w-[32.5rem] xl:h-[15.9375rem] xl:w-[50.625rem]">
+        <Image
+          src="/contents/img_team_empty_desktop.png"
+          alt="소속된 팀이 없습니다."
+          fill
+        />
+      </div>
+      <div className="mb-12 text-center text-md font-medium text-text-default tablet:mb-20 tablet:text-lg xl:text-lg">
+        페이지를 찾을 수 없습니다.
+        <br />
+        팀을 생성하거나 팀에 참여해보세요.
+      </div>
+      <Link
+        href="/addteam"
+        className="mb-2 flex h-12 w-[11.625rem] items-center justify-center rounded-xl bg-brand-primary text-md font-semibold"
+      >
+        팀 생성하기
+      </Link>
+      <Link
+        href="/invitation"
+        className="flex h-12 w-[11.625rem] items-center justify-center rounded-xl border-[1px] border-brand-primary bg-transparent text-md font-semibold text-brand-primary"
+      >
+        팀 참여하기
+      </Link>
+    </div>
+  );
+}
+
+export default NotFound;


### PR DESCRIPTION
### 이슈 번호

close #124

### 변경 사항 요약
- Not Found(404) 페이지 추가
- Not Found(404) 테스트용 임시 로딩 컴포넌트 추가
- Not Found(404 리다이렉트 커스텀 훅 추가

### 테스트 결과
#### 팀 & 할 일 목록
https://github.com/user-attachments/assets/8997d5db-1ab0-47d6-bd28-fb859aad175d

#### 자유 게시판 & global 404 
https://github.com/user-attachments/assets/6ca21019-e570-4408-afcf-a32e410c0c88

#### react-query retry 옵션 제거

https://github.com/user-attachments/assets/0c7d84dd-d918-4a4a-866a-8d0a01fb0a9f


### 리뷰포인트
- 현재 react-query의 retry 옵션이 기본 3회라서 not found 처리가 어색하게 보입니다. retry 옵션 제거 영상 보시고 논의하면 좋을 것 같습니다.
- dynamic routes에서 404 처리를 하려면 SSR이 필요합니다. 
현재 모든 페이지가 CSR로 작업 되어있어 404 리다이렉트 로직을 client-side에서 커스텀 훅으로 처리했습니다.
동작 확인해보시고 404 처리 추가 관련해서 논의하면 좋을 것 같습니다.