### PR TITLE
자유게시판 상세페이지, 마이페이지 리팩토링

### DIFF
--- a/src/app/(routes)/addboard/page.tsx
+++ b/src/app/(routes)/addboard/page.tsx
@@ -97,7 +97,7 @@ export default function AddBoard() {
                 {...methods.register('content', { required: true })}
               />
             </div>
-            <div>
+            <div className="mb-10">
               <h4 className="mb-4 flex gap-1.5 text-md tablet:text-lg">
                 이미지
               </h4>

--- a/src/app/(routes)/addboard/page.tsx
+++ b/src/app/(routes)/addboard/page.tsx
@@ -83,7 +83,7 @@ export default function AddBoard() {
               </h2>
               <input
                 placeholder="제목을 입력해주세요."
-                className="w-full rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-3 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400"
+                className="w-full rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-3 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400 focus:border-interaction-focus focus:outline-none"
                 {...methods.register('title', { required: true })}
               />
             </div>
@@ -93,7 +93,7 @@ export default function AddBoard() {
               </h3>
               <textarea
                 placeholder="내용을 입력해주세요."
-                className="h-[15rem] w-full resize-none rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-4 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400"
+                className="custom-scrollbar h-[15rem] w-full resize-none rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-4 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400 focus:border-interaction-focus focus:outline-none"
                 {...methods.register('content', { required: true })}
               />
             </div>

--- a/src/app/(routes)/mypage/page.tsx
+++ b/src/app/(routes)/mypage/page.tsx
@@ -1,16 +1,22 @@
 'use client';
 
-import ProfileChanger from '@/app/components/mypage/ProflieChanger';
 import { useForm } from 'react-hook-form';
 import { useQuery } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/app/stores/store';
 import getUser, { GetUserResponse } from '@/app/lib/user/getUser';
 import DeleteAccount from '@/app/components/mypage/DeleteAccount';
 import ResetPassword from '@/app/components/mypage/ResetPassword';
 import NicknameChanger from '@/app/components/mypage/NicknameChanger';
+import ProfileChanger from '@/app/components/mypage/ProflieChanger';
+import useAuthRedirect from '@/app/hooks/useAuthRedirect';
 
 export default function MyPage() {
   const method = useForm();
   const { register } = method;
+  const { isLoading: isAuthLoading } = useAuthRedirect();
+
+  const accessToken = useSelector((state: RootState) => state.auth.accessToken);
 
   const {
     data: userData,
@@ -20,10 +26,11 @@ export default function MyPage() {
   } = useQuery<GetUserResponse>({
     queryKey: ['user'],
     queryFn: getUser,
+    enabled: !!accessToken, // 로그인 상태일 때만 실행
   });
 
-  if (isLoading) {
-    return <div className="text-center">사용자 정보를 불러오는 중</div>;
+  if (isAuthLoading || isLoading) {
+    return <div className="text-center">사용자 정보를 불러오는 중...</div>;
   }
 
   if (isError) {

--- a/src/app/components/boarddetail/AddComment.tsx
+++ b/src/app/components/boarddetail/AddComment.tsx
@@ -26,7 +26,7 @@ export default function AddComment() {
       <div className="tablet:text-xl">댓글 달기</div>
       <textarea
         placeholder="내용을 입력해주세요."
-        className="h-[6.5rem] w-full resize-none rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-4 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400 focus:border-interaction-focus focus:outline-none placeholder:tablet:text-lg"
+        className="custom-scrollbar h-[6.5rem] w-full resize-none rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-4 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400 focus:border-interaction-focus focus:outline-none placeholder:tablet:text-lg"
         value={commentContent}
         onChange={(e) => setCommentContent(e.target.value)}
       />

--- a/src/app/components/boarddetail/AddComment.tsx
+++ b/src/app/components/boarddetail/AddComment.tsx
@@ -26,7 +26,7 @@ export default function AddComment() {
       <div className="tablet:text-xl">댓글 달기</div>
       <textarea
         placeholder="내용을 입력해주세요."
-        className="h-[6.5rem] w-full resize-none rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-4 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400 placeholder:tablet:text-lg"
+        className="h-[6.5rem] w-full resize-none rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-4 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400 focus:border-interaction-focus focus:outline-none placeholder:tablet:text-lg"
         value={commentContent}
         onChange={(e) => setCommentContent(e.target.value)}
       />

--- a/src/app/components/boarddetail/AddComment.tsx
+++ b/src/app/components/boarddetail/AddComment.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'next/navigation';
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import postArticleComment from '@/app/lib/articlecomment/postArticleComment';
-import Button from '../common/button/Button';
+import Button from '@/app/components/common/button/Button';
 
 export default function AddComment() {
   const params = useParams();

--- a/src/app/components/boarddetail/BoardDetail.tsx
+++ b/src/app/components/boarddetail/BoardDetail.tsx
@@ -73,7 +73,7 @@ export default function BoardDetail({ article }: BoardDetailProps) {
           <div className="flex w-full items-center gap-2 py-6">
             <input
               type="text"
-              className="h-8 w-[90%] resize-none rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-4 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400 placeholder:tablet:text-lg"
+              className="h-12 w-[90%] resize-none rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-4 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400 focus:border-interaction-focus focus:outline-none placeholder:tablet:text-lg"
               value={editedTitle}
               onChange={(e) => setEditedTitle(e.target.value)}
             />
@@ -144,7 +144,7 @@ export default function BoardDetail({ article }: BoardDetailProps) {
         {isEditing ? (
           <div>
             <textarea
-              className="w-full resize-none rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-4 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400 placeholder:tablet:text-lg"
+              className="w-full resize-none rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-4 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400 focus:border-interaction-focus focus:outline-none placeholder:tablet:text-lg"
               rows={5}
               value={editedContent}
               onChange={(e) => setEditedContent(e.target.value)}

--- a/src/app/components/boarddetail/BoardDetail.tsx
+++ b/src/app/components/boarddetail/BoardDetail.tsx
@@ -137,14 +137,6 @@ export default function BoardDetail({ article }: BoardDetailProps) {
             className="rounded-lg"
             objectFit="cover"
           />
-          <Image
-            src={article.image}
-            alt="게시글 이미지"
-            width={343}
-            height={343}
-            className="rounded-lg"
-            objectFit="cover"
-          />
         </div>
       )}
 

--- a/src/app/components/boarddetail/BoardDetail.tsx
+++ b/src/app/components/boarddetail/BoardDetail.tsx
@@ -173,11 +173,6 @@ export default function BoardDetail({ article }: BoardDetailProps) {
         onClose={closeModal}
         articleId={article.id}
       />
-      <DeleteArticleModal
-        isOpen={isOpen}
-        onClose={closeModal}
-        articleId={article.id}
-      />
     </>
   );
 }

--- a/src/app/components/boarddetail/BoardDetail.tsx
+++ b/src/app/components/boarddetail/BoardDetail.tsx
@@ -17,9 +17,9 @@ import Dropdown from '@/app/components/common/dropdown/Dropdown';
 import DropdownToggle from '@/app/components/common/dropdown/DropdownToggle';
 import DropdownList from '@/app/components/common/dropdown/DropdownList';
 import DropdownItem from '@/app/components/common/dropdown/DropdownItem';
-import BoardsLikeBox from '../boards/BoardsLikeBox';
-import DeleteArticleModal from './DeleteArticleModal';
-import Button from '../common/button/Button';
+import BoardsLikeBox from '@/app/components/boards/BoardsLikeBox';
+import DeleteArticleModal from '@/app/components/boarddetail/DeleteArticleModal';
+import Button from '@/app/components/common/button/Button';
 
 interface BoardDetailProps {
   article: GetArticleDetailResponse;

--- a/src/app/components/boarddetail/BoardDetail.tsx
+++ b/src/app/components/boarddetail/BoardDetail.tsx
@@ -12,11 +12,12 @@ import Image from 'next/image';
 import useModal from '@/app/hooks/useModal';
 import IconMore from '@/app/components/icons/IconMore';
 import IconComment from '@/app/components/icons/IconComment';
-import BoardsLikeBox from '../boards/BoardsLikeBox';
+
 import Dropdown from '@/app/components/common/dropdown/Dropdown';
 import DropdownToggle from '@/app/components/common/dropdown/DropdownToggle';
 import DropdownList from '@/app/components/common/dropdown/DropdownList';
 import DropdownItem from '@/app/components/common/dropdown/DropdownItem';
+import BoardsLikeBox from '../boards/BoardsLikeBox';
 import DeleteArticleModal from './DeleteArticleModal';
 import Button from '../common/button/Button';
 
@@ -39,7 +40,9 @@ export default function BoardDetail({ article }: BoardDetailProps) {
   const editMutation = useMutation({
     mutationFn: (data: PatchArticleRequest) => patchArticle(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['articleDetail', article.id] });
+      queryClient.invalidateQueries({
+        queryKey: ['articleDetail', article.id],
+      });
       setIsEditing(false);
     },
   });
@@ -95,7 +98,6 @@ export default function BoardDetail({ article }: BoardDetailProps) {
             </DropdownList>
           </Dropdown>
         )}
-
       </div>
 
       <div className="flex h-[4.5rem] items-center justify-between">
@@ -109,19 +111,32 @@ export default function BoardDetail({ article }: BoardDetailProps) {
               .replace(/\.$/, '')}
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-3">
           <div className="flex items-center gap-1 text-xs text-text-disabled tablet:text-md">
-            <IconComment />
-            {article.commentCount}
-            <BoardsLikeBox id={article.id} likeCount={article.likeCount} isLiked={article.isLiked} />
+            <div className="mr-2 flex items-center gap-1">
+              <IconComment />
+              {article.commentCount}
+            </div>
+
+            <BoardsLikeBox
+              id={article.id}
+              likeCount={article.likeCount}
+              isLiked={article.isLiked}
+            />
           </div>
-          
         </div>
       </div>
 
       {article.image && (
         <div className="mb-4">
-          <Image src={article.image} alt="게시글 이미지" width={343} height={343} className="rounded-lg" objectFit="cover" />
+          <Image
+            src={article.image}
+            alt="게시글 이미지"
+            width={343}
+            height={343}
+            className="rounded-lg"
+            objectFit="cover"
+          />
         </div>
       )}
 
@@ -135,7 +150,11 @@ export default function BoardDetail({ article }: BoardDetailProps) {
               onChange={(e) => setEditedContent(e.target.value)}
             />
             <div className="mt-2 flex justify-end gap-2">
-              <Button variant="cancel" size="small" onClick={() => setIsEditing(false)}>
+              <Button
+                variant="cancel"
+                size="small"
+                onClick={() => setIsEditing(false)}
+              >
                 취소
               </Button>
               <Button variant="primary" size="small" onClick={handleEditSubmit}>
@@ -149,7 +168,11 @@ export default function BoardDetail({ article }: BoardDetailProps) {
       </div>
 
       {/* 삭제 확인 모달 */}
-      <DeleteArticleModal isOpen={isOpen} onClose={closeModal} articleId={article.id} />
+      <DeleteArticleModal
+        isOpen={isOpen}
+        onClose={closeModal}
+        articleId={article.id}
+      />
     </>
   );
 }

--- a/src/app/components/boarddetail/CommentDropdown.tsx
+++ b/src/app/components/boarddetail/CommentDropdown.tsx
@@ -5,8 +5,8 @@ import DropdownToggle from '@/app/components/common/dropdown/DropdownToggle';
 import DropdownList from '@/app/components/common/dropdown/DropdownList';
 import DropdownItem from '@/app/components/common/dropdown/DropdownItem';
 import useModal from '@/app/hooks/useModal';
-import IconMore from '../icons/IconMore';
-import DeleteCommentModal from './DeleteCommentModal';
+import IconMore from '@/app/components/icons/IconMore';
+import DeleteCommentModal from '@/app/components/boarddetail/DeleteCommentModal';
 
 interface CommentDropdownProps {
   commentId: number;

--- a/src/app/components/boarddetail/CommentList.tsx
+++ b/src/app/components/boarddetail/CommentList.tsx
@@ -21,10 +21,10 @@ import deleteArticleComment, {
 } from '@/app/lib/articlecomment/deleteArticleComment';
 import Image from 'next/image';
 
-import AddComment from './AddComment';
-import CommentDropdown from './CommentDropdown';
-import Button from '../common/button/Button';
-import IconMember from '../icons/IconMember';
+import AddComment from '@/app/components/boarddetail/AddComment';
+import CommentDropdown from '@/app/components/boarddetail/CommentDropdown';
+import Button from '@/app/components/common/button/Button';
+import IconMember from '@/app/components/icons/IconMember';
 
 export default function CommentList() {
   const params = useParams();

--- a/src/app/components/boarddetail/CommentList.tsx
+++ b/src/app/components/boarddetail/CommentList.tsx
@@ -163,7 +163,10 @@ export default function CommentList() {
                     </div>
                   ) : (
                     <div className="flex justify-between">
-                      <span>{comment.content}</span>
+                      <div className="w-[97%] whitespace-pre-wrap break-words break-all">
+                        {comment.content}
+                      </div>
+
                       {isCommentAuthor && (
                         <CommentDropdown
                           commentId={comment.id}

--- a/src/app/components/boarddetail/CommentList.tsx
+++ b/src/app/components/boarddetail/CommentList.tsx
@@ -121,7 +121,6 @@ export default function CommentList() {
       <AddComment />
 
       <div className="mt-8 flex flex-col gap-4 tablet:mt-10">
-
         {data?.pages.map((page) =>
           page.list.map((comment) => {
             // 현재 로그인한 사용자가 해당 댓글의 작성자인지 확인
@@ -130,23 +129,20 @@ export default function CommentList() {
               String(currentUserId) === String(comment.writer.id);
 
             return (
-
               <div
                 key={comment.id}
                 className="rounded-lg border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary p-4"
               >
                 <div className="flex flex-col gap-8">
-
                   {editingCommentId === comment.id ? (
                     <div className="relative flex flex-col">
-                      <input
-                        type="text"
-                        className="w-full bg-background-secondary pb-6 pt-0.5"
+                      <textarea
+                        className="custom-scrollbar flex h-20 w-full resize-none items-center justify-center rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-2 pl-4 text-start focus:border-interaction-focus focus:outline-none"
                         value={editedContent}
                         onChange={(e) => setEditedContent(e.target.value)}
                       />
 
-                      <div className="mt-2 flex justify-end gap-2">
+                      <div className="mt-4 flex justify-end gap-2">
                         <button
                           type="button"
                           onClick={handleEditCancel}
@@ -166,7 +162,7 @@ export default function CommentList() {
                       </div>
                     </div>
                   ) : (
-                    <div className="flex items-center justify-between">
+                    <div className="flex justify-between">
                       <span>{comment.content}</span>
                       {isCommentAuthor && (
                         <CommentDropdown
@@ -179,7 +175,6 @@ export default function CommentList() {
                   )}
 
                   {editingCommentId !== comment.id && (
-
                     <div className="flex items-center gap-2">
                       {comment.writer.image ? (
                         <Image
@@ -196,7 +191,6 @@ export default function CommentList() {
                         {comment.writer.nickname}
                       </p>
                       <p className="border-l-[0.063rem] border-text-primary border-opacity-10 pl-2 text-xs text-text-disabled tablet:text-md">
-
                         {new Date(comment.createdAt)
                           .toLocaleDateString()
                           .replace(/\.$/, '')}
@@ -207,7 +201,6 @@ export default function CommentList() {
               </div>
             );
           }),
-
         )}
       </div>
 

--- a/src/app/components/boarddetail/DeleteArticleModal.tsx
+++ b/src/app/components/boarddetail/DeleteArticleModal.tsx
@@ -3,9 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
 import deleteArticle from '@/app/lib/article/deleteArticle';
-import Modal from '@/app/components/common/modal/Modal';
-import Button from '@/app/components/common/button/Button';
-import IconAlert from '@/app/components/icons/IconAlert';
+import ConfirmModal from '@/app/components/common/modal/ConfirmModal';
 
 interface DeleteArticleModalProps {
   isOpen: boolean;
@@ -31,29 +29,20 @@ export default function DeleteArticleModal({
   });
 
   return (
-    <Modal isOpen={isOpen} closeModal={onClose}>
-      <div className="flex flex-col items-center">
-        <IconAlert />
-        <div className="mt-4 flex w-[239px] flex-col items-center">
+    <ConfirmModal
+      title={
+        <div className="flex flex-col items-center">
           <h2 className="mb-4 text-lg font-light">게시글을 삭제하시겠어요?</h2>
-          <p className="mb-6 text-center text-md font-thin">
+          <p className="mb-4 text-center text-md font-thin">
             삭제된 게시글은 복구할 수 없습니다.
           </p>
         </div>
-
-        <div className="flex justify-end gap-4">
-          <Button onClick={onClose} variant="secondary" className="w-[8.5rem]">
-            닫기
-          </Button>
-          <Button
-            onClick={() => deleteMutation.mutate()}
-            variant="danger"
-            className="w-[8.5rem]"
-          >
-            삭제하기
-          </Button>
-        </div>
-      </div>
-    </Modal>
+      }
+      cancelLabel="닫기"
+      confirmLabel="삭제하기"
+      isModalOpen={isOpen}
+      handleCancel={onClose}
+      handleConfirm={() => deleteMutation.mutate()}
+    />
   );
 }

--- a/src/app/components/boarddetail/DeleteCommentModal.tsx
+++ b/src/app/components/boarddetail/DeleteCommentModal.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import Modal from '@/app/components/common/modal/Modal';
-import Button from '@/app/components/common/button/Button';
-import IconAlert from '@/app/components/icons/IconAlert';
+import ConfirmModal from '@/app/components/common/modal/ConfirmModal';
 
 interface DeleteCommentModalProps {
   isOpen: boolean;
@@ -16,25 +14,20 @@ export default function DeleteCommentModal({
   onConfirm,
 }: DeleteCommentModalProps) {
   return (
-    <Modal isOpen={isOpen} closeModal={onClose}>
-      <div className="flex flex-col items-center">
-        <IconAlert />
-        <div className="mt-4 flex w-[239px] flex-col items-center">
+    <ConfirmModal
+      title={
+        <div className="flex flex-col items-center">
           <h2 className="mb-4 text-lg font-light">댓글을 삭제하시겠어요?</h2>
-          <p className="mb-6 text-center text-md font-thin">
+          <p className="mb-4 text-center text-md font-thin">
             삭제된 댓글은 복구할 수 없습니다.
           </p>
         </div>
-
-        <div className="flex justify-end gap-4">
-          <Button onClick={onClose} variant="secondary" className="w-[8.5rem]">
-            닫기
-          </Button>
-          <Button onClick={onConfirm} variant="danger" className="w-[8.5rem]">
-            삭제하기
-          </Button>
-        </div>
-      </div>
-    </Modal>
+      }
+      cancelLabel="닫기"
+      confirmLabel="삭제하기"
+      isModalOpen={isOpen}
+      handleCancel={onClose}
+      handleConfirm={onConfirm}
+    />
   );
 }

--- a/src/app/components/editboard/ArticleChanger.tsx
+++ b/src/app/components/editboard/ArticleChanger.tsx
@@ -46,7 +46,7 @@ export default function ArticleChanger({
           value={title}
           onChange={handleTitleChange}
           placeholder="제목을 입력해주세요."
-          className="w-full rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-3 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400"
+          className="w-full rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-3 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400 focus:border-interaction-focus focus:outline-none"
         />
       </div>
 
@@ -61,7 +61,7 @@ export default function ArticleChanger({
             onContentChange(e.target.value);
           }}
           placeholder="내용을 입력해주세요."
-          className="custom-scrollbar h-[15rem] w-full resize-none rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-4 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400"
+          className="custom-scrollbar h-[15rem] w-full resize-none rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-4 pl-4 placeholder:text-md placeholder:font-light placeholder:text-gray-400 focus:border-interaction-focus focus:outline-none"
         />
       </div>
     </div>

--- a/src/app/components/editboard/ImageChanger.tsx
+++ b/src/app/components/editboard/ImageChanger.tsx
@@ -52,7 +52,7 @@ export default function ImageChanger({
   };
 
   return (
-    <div>
+    <div className="mb-10">
       <h4 className="mb-4 mt-6 flex gap-1.5 text-md tablet:mt-10 tablet:text-lg">
         이미지
       </h4>

--- a/src/app/components/myhistory/HistoryList.tsx
+++ b/src/app/components/myhistory/HistoryList.tsx
@@ -4,8 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import getHistory, { Task } from '@/app/lib/user/getHistory';
 import { formatDate } from '@/app/utils/formatDate';
 import useAuthRedirect from '@/app/hooks/useAuthRedirect';
-import IconCheckBox from '../icons/IconCheckBox';
-import HistoryListSkeleton from './HistoryListSkeleton';
+import IconCheckBox from '@/app/components/icons/IconCheckBox';
+import HistoryListSkeleton from '@/app/components/myhistory/HistoryListSkeleton';
 
 // task.date 기준으로 데이터 그룹화
 const groupByDate = (tasks: Task[]) => {

--- a/src/app/components/myhistory/HistoryList.tsx
+++ b/src/app/components/myhistory/HistoryList.tsx
@@ -3,8 +3,9 @@
 import { useQuery } from '@tanstack/react-query';
 import getHistory, { Task } from '@/app/lib/user/getHistory';
 import { formatDate } from '@/app/utils/formatDate';
+import useAuthRedirect from '@/app/hooks/useAuthRedirect';
 import IconCheckBox from '../icons/IconCheckBox';
-import HistoryLIstSkeleton from './HistoryListSkeleton';
+import HistoryListSkeleton from './HistoryListSkeleton';
 
 // task.date 기준으로 데이터 그룹화
 const groupByDate = (tasks: Task[]) => {
@@ -19,13 +20,15 @@ const groupByDate = (tasks: Task[]) => {
 };
 
 export default function HistoryList() {
+  const { isLoading: isAuthLoading } = useAuthRedirect();
+
   const { data, error, isLoading } = useQuery({
     queryKey: ['history'],
     queryFn: getHistory,
   });
 
-  if (isLoading) {
-    return <HistoryLIstSkeleton />;
+  if (isLoading || isAuthLoading) {
+    return <HistoryListSkeleton />;
   }
 
   if (error) {

--- a/src/app/components/mypage/DeleteAccount.tsx
+++ b/src/app/components/mypage/DeleteAccount.tsx
@@ -3,10 +3,8 @@
 import { useMutation } from '@tanstack/react-query';
 import deleteUser, { DeleteUserResponse } from '@/app/lib/user/deleteUser';
 import useModal from '@/app/hooks/useModal';
-import Modal from '../common/modal/Modal';
+import ConfirmModal from '../common/modal/ConfirmModal';
 import IconSubtract from '../icons/IconSubtract';
-import Button from '../common/button/Button';
-import IconAlert from '../icons/IconAlert';
 
 export default function DeleteAccount() {
   const { isOpen: isModalOpen, openModal, closeModal } = useModal();
@@ -38,37 +36,24 @@ export default function DeleteAccount() {
         <span className="text-lg font-light text-point-red">회원 탈퇴하기</span>
       </button>
 
-      <Modal isOpen={isModalOpen} closeModal={closeModal}>
-        <div className="flex flex-col items-center">
-          <IconAlert />
-          <div className="mt-4 flex w-[239px] flex-col items-center">
+      <ConfirmModal
+        title={
+          <div className="flex flex-col items-center">
             <h2 className="mb-4 text-lg font-light">
               회원 탈퇴를 진행하시겠어요?
             </h2>
-            <p className="mb-6 text-center text-md font-thin">
+            <p className="mb-4 text-center text-md font-thin">
               그룹장으로 있는 그룹은 자동으로 삭제되고, 모든 그룹에서
               나가집니다.
             </p>
           </div>
-
-          <div className="flex justify-end gap-4">
-            <Button
-              onClick={closeModal}
-              variant="secondary"
-              className="w-[8.5rem]"
-            >
-              취소
-            </Button>
-            <Button
-              onClick={handleDelete}
-              variant="danger"
-              className="w-[8.5rem]"
-            >
-              회원 탈퇴
-            </Button>
-          </div>
-        </div>
-      </Modal>
+        }
+        cancelLabel="취소"
+        confirmLabel="회원 탈퇴"
+        isModalOpen={isModalOpen}
+        handleCancel={closeModal}
+        handleConfirm={handleDelete}
+      />
     </div>
   );
 }

--- a/src/app/components/mypage/DeleteAccount.tsx
+++ b/src/app/components/mypage/DeleteAccount.tsx
@@ -1,18 +1,22 @@
 'use client';
 
 import { useMutation } from '@tanstack/react-query';
+import { useDispatch } from 'react-redux';
+import { logout } from '@/app/stores/auth/authSlice';
 import deleteUser, { DeleteUserResponse } from '@/app/lib/user/deleteUser';
 import useModal from '@/app/hooks/useModal';
 import ConfirmModal from '../common/modal/ConfirmModal';
 import IconSubtract from '../icons/IconSubtract';
 
 export default function DeleteAccount() {
+  const dispatch = useDispatch();
   const { isOpen: isModalOpen, openModal, closeModal } = useModal();
 
   const mutation = useMutation<DeleteUserResponse, Error>({
     mutationFn: deleteUser,
     onSuccess: () => {
       alert('회원 탈퇴가 완료되었습니다.');
+      dispatch(logout()); // Redux Store 초기화
       closeModal();
       window.location.href = '/';
     },
@@ -23,7 +27,6 @@ export default function DeleteAccount() {
 
   const handleDelete = () => {
     mutation.mutate();
-    closeModal();
   };
 
   return (

--- a/src/app/components/mypage/DeleteAccount.tsx
+++ b/src/app/components/mypage/DeleteAccount.tsx
@@ -5,8 +5,8 @@ import { useDispatch } from 'react-redux';
 import { logout } from '@/app/stores/auth/authSlice';
 import deleteUser, { DeleteUserResponse } from '@/app/lib/user/deleteUser';
 import useModal from '@/app/hooks/useModal';
-import ConfirmModal from '../common/modal/ConfirmModal';
-import IconSubtract from '../icons/IconSubtract';
+import ConfirmModal from '@/app/components/common/modal/ConfirmModal';
+import IconSubtract from '@/app/components/icons/IconSubtract';
 
 export default function DeleteAccount() {
   const dispatch = useDispatch();

--- a/src/app/components/mypage/NicknameChanger.tsx
+++ b/src/app/components/mypage/NicknameChanger.tsx
@@ -17,7 +17,12 @@ export default function NicknameChanger({
   refetchUser,
 }: NicknameChangerProps) {
   const methods = useForm({ defaultValues: { nickname: currentNickname } });
-  const { watch, handleSubmit } = methods;
+  const {
+    watch,
+    handleSubmit,
+    register,
+    formState: { errors },
+  } = methods;
   const { isOpen, openModal, closeModal } = useModal();
   const newNickname = watch('nickname');
 
@@ -53,8 +58,12 @@ export default function NicknameChanger({
         <div className="relative flex w-full items-center">
           <input
             className="w-full rounded-xl border-[0.063rem] border-text-primary border-opacity-10 bg-background-secondary py-3 pl-4 focus:border-interaction-focus focus:outline-none"
-            {...methods.register('nickname', {
+            {...register('nickname', {
               required: '닉네임을 입력하세요.',
+              maxLength: {
+                value: 30,
+                message: '닉네임은 최대 30자까지 입력할 수 있습니다.',
+              },
             })}
             type="text"
             placeholder="새 닉네임 입력"
@@ -66,6 +75,13 @@ export default function NicknameChanger({
             </Button>
           </div>
         </div>
+
+        {/* 닉네임 길이 제한 오류 메시지 */}
+        {errors.nickname && (
+          <p className="ml-2 mt-3 text-sm text-point-red">
+            {errors.nickname.message}
+          </p>
+        )}
       </form>
 
       <Modal isOpen={isOpen} closeModal={closeModal} hasCloseBtn>

--- a/src/app/components/mypage/ResetPassword.tsx
+++ b/src/app/components/mypage/ResetPassword.tsx
@@ -6,9 +6,9 @@ import useModal from '@/app/hooks/useModal';
 import getUser, { GetUserResponse } from '@/app/lib/user/getUser';
 import { SignInResponse, FormData } from '@/app/types/AuthType';
 import postSignInApi from '@/app/lib/auth/postSignInApi';
-import Input from '../common/input/Input';
-import Button from '../common/button/Button';
-import ResetPasswordModal from './ResetPasswordModal';
+import Input from '@/app/components/common/input/Input';
+import Button from '@/app/components/common/button/Button';
+import ResetPasswordModal from '@/app/components/mypage/ResetPasswordModal';
 
 export default function ResetPassword() {
   const methods = useForm<FormData>();

--- a/src/app/components/mypage/ResetPasswordModal.tsx
+++ b/src/app/components/mypage/ResetPasswordModal.tsx
@@ -3,9 +3,9 @@
 import { FormProvider, useForm } from 'react-hook-form';
 import { useMutation } from '@tanstack/react-query';
 import patchPassword from '@/app/lib/user/patchPassword';
-import Modal from '../common/modal/Modal';
-import Input from '../common/input/Input';
-import Button from '../common/button/Button';
+import Modal from '@/app/components/common/modal/Modal';
+import Input from '@/app/components/common/input/Input';
+import Button from '@/app/components/common/button/Button';
 
 interface FormData {
   newPassword: string;


### PR DESCRIPTION
### 이슈 번호

close #130 

### 변경 사항 요약

- 회원 탈퇴 시 redux store 초기화
- useAuthRedirect 훅 적용
- 삭제 확인 모달 공통 컴포넌트로 리팩토링
- 닉네임 30자 제한 에러메시지 노출
- input border 리팩토링
- 제출 폼 패딩 추가
- 자유게시판 상세페이지 댓글 박스 초과시 줄바꿈

### 테스트 결과

- 회원 탈퇴
https://github.com/user-attachments/assets/60583fe8-23ad-4b92-baa9-0815cf3e6823

- 로그인 필요한 페이지
https://github.com/user-attachments/assets/1bf27f02-753d-43a8-90e9-488ca4c1dd3a

- 닉네임 30자 제한
https://github.com/user-attachments/assets/70f1e10b-f0d4-484f-bb43-af4396154716

### 리뷰포인트

- 중간중간 발견한 자잘한 이슈들이 많아서 파일 많은 점 죄송합니다 ㅜㅜ