### PR TITLE
Header부분 로그아웃하고 바로 다른 계정으로 로그인할때 생기는 이슈 해결완료

### DIFF
--- a/src/app/components/common/header/Header.tsx
+++ b/src/app/components/common/header/Header.tsx
@@ -30,6 +30,7 @@ export default function Header() {
   const { data: userData } = useQuery<GetUserResponse>({
     queryKey: ['user'],
     queryFn: getUser,
+    enabled: Boolean(accessToken),
   });
   const isLoggedIn = !!accessToken;
 


### PR DESCRIPTION
### 이슈 번호

- #18

### 변경 사항 요약

- 기존계정에서 로그아웃하고 다른 아이디로 로그인을 바로할떄 user이름이 기존 데이터가 가져와지고 새로 로그인한 아이디 데이터가 늦게 가져와지는거 수정완료

### 테스트 결과

#### 문제 영상

https://github.com/user-attachments/assets/0c74bbff-690f-474c-97c1-7e9b6a023cdb

#### 해결 영상

https://github.com/user-attachments/assets/b0edee57-7dc7-46e7-93df-5ecfd6d93d96


### 리뷰포인트
