### PR TITLE
할 일 리스트/상세 컴포넌트 리팩토링 #3

### DIFF
--- a/src/app/(routes)/[teamid]/[tasklist]/page.tsx
+++ b/src/app/(routes)/[teamid]/[tasklist]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import useModal from '@/app/hooks/useModal';
 import useSaveScroll from '@/app/hooks/useSaveScroll';
@@ -19,10 +19,12 @@ import TaskCardList from '@/app/components/tasklist/TaskCardList';
 import CreateTaskModal from '@/app/components/tasklist/CreateTaskModal';
 import CreateListModal from '@/app/components/tasklist/CreateListModal';
 import TaskCardSkeleton from '@/app/components/tasklist/TaskCardSkeleton';
+import IconBack from '@/app/components/icons/IconBack';
 
 function TaskListPage() {
-  const { isLoading: isAuthLoading } = useAuthRedirect();
+  const router = useRouter();
   const { teamid, tasklist } = useParams();
+  const { isLoading: isAuthLoading } = useAuthRedirect();
   const { isOpen, openModal, closeModal } = useModal();
   const [modalType, setModalType] = useState<'list' | 'task' | null>(null);
   const [selectedDate, setSelectedDate] = useState<string>(
@@ -58,6 +60,12 @@ function TaskListPage() {
     openModal();
   };
 
+  const handleBack = () => {
+    if (teamid) {
+      router.push(`/${teamid}`);
+    }
+  };
+
   const isLoading =
     isTeamLoading || (!groupData && !taskListData && !isTaskListLoading);
 
@@ -74,6 +82,9 @@ function TaskListPage() {
 
   return (
     <div className="mx-auto mt-24 flex w-full max-w-[75rem] flex-col gap-6 px-3.5 tablet:px-6">
+      <button onClick={handleBack} className="cursor-pointer">
+        <IconBack />
+      </button>
       <p className="text-xl">할 일</p>
       <div className="flex justify-between">
         <DatePicker

--- a/src/app/(routes)/[teamid]/[tasklist]/page.tsx
+++ b/src/app/(routes)/[teamid]/[tasklist]/page.tsx
@@ -81,7 +81,7 @@ function TaskListPage() {
   if (isLoading || isRedirecting) return <Loading />;
 
   return (
-    <div className="mx-auto mt-24 flex w-full max-w-[75rem] flex-col gap-6 px-3.5 tablet:px-6">
+    <div className="mx-auto mt-24 flex w-full max-w-[75rem] flex-col gap-5 px-3.5 tablet:px-6">
       <button onClick={handleBack} className="cursor-pointer">
         <IconBack />
       </button>

--- a/src/app/components/icons/IconBack.tsx
+++ b/src/app/components/icons/IconBack.tsx
@@ -1,0 +1,19 @@
+export default function IconBack() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth="1.5"
+      stroke="currentColor"
+      className="group size-6 cursor-pointer"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3"
+        className="group-hover:stroke-[#059669]"
+      />
+    </svg>
+  );
+}

--- a/src/app/components/taskdetail/TaskDetail.tsx
+++ b/src/app/components/taskdetail/TaskDetail.tsx
@@ -272,6 +272,7 @@ function TaskDetail({
               variant={doneAt ? 'cancel' : 'complete'}
               size={doneAt ? 'cancel' : 'complete'}
               onClick={toggleDone}
+              className="transform duration-200"
             >
               <IconCheck />
               {doneAt ? '완료 취소하기' : '완료하기'}

--- a/src/app/components/tasklist/CreateListModal.tsx
+++ b/src/app/components/tasklist/CreateListModal.tsx
@@ -48,7 +48,7 @@ export default function CreateListModal({
           if (error instanceof AxiosError && error.response?.status === 409) {
             setError('name', {
               type: 'manual',
-              message: '이미 존재하는 목록입니다.',
+              message: '그룹 내 이름이 같은 할 일 목록이 존재합니다.',
             });
           }
         },
@@ -59,7 +59,7 @@ export default function CreateListModal({
   return (
     <Modal isOpen={isOpen} closeModal={onClose}>
       <div className="mb-4 flex w-[17.5rem] w-full flex-col gap-4 text-center">
-        <p className="text-lg font-medium">새로운 목록 추가</p>
+        <p className="text-lg font-medium">할 일 목록 추가</p>
         <p className="text-md text-text-secondary">
           할 일에 대한 목록을 추가하고
           <br />
@@ -72,19 +72,18 @@ export default function CreateListModal({
           <div className="flex w-full flex-col gap-6">
             <Input
               name="name"
-              title="목록 이름"
               type="text"
-              placeholder="할 일 목록을 입력해주세요."
+              placeholder="목록 이름을 입력해주세요."
               autoComplete="off"
               validationRules={{
-                required: '할 일 목록을 입력해주세요.',
+                required: '목록 이름을 입력해주세요.',
                 maxLength: {
                   value: 30,
-                  message: '할 일 목록은 최대 30글자까지 입력 가능합니다.',
+                  message: '목록 이름은 최대 30글자까지 입력 가능합니다.',
                 },
                 validate: (value) =>
                   value.trim() !== '' ||
-                  '할 일 목록은 공백만 입력할 수 없습니다.',
+                  '목록 이름은 공백만 입력할 수 없습니다.',
               }}
             />
 

--- a/src/app/components/team/TaskListDropdown.tsx
+++ b/src/app/components/team/TaskListDropdown.tsx
@@ -124,11 +124,11 @@ export default function TaskListDropdown({
                   required: '목록 이름을 입력해주세요.',
                   maxLength: {
                     value: 30,
-                    message: '할 일 제목은 최대 30글자까지 입력 가능합니다.',
+                    message: '목록 이름은 최대 30글자까지 입력 가능합니다.',
                   },
                   validate: (value: string) => {
                     if (value.trim().length === 0) {
-                      return '할 일 제목에 공백만 입력할 수 없습니다.';
+                      return '목록 이름은 공백만 입력할 수 없습니다.';
                     }
                     return true;
                   },

--- a/src/app/components/team/TodoList.tsx
+++ b/src/app/components/team/TodoList.tsx
@@ -183,11 +183,11 @@ export default function TodoList({ groupId, taskLists }: TodoListProps) {
                     required: '목록 이름을 입력해주세요.',
                     maxLength: {
                       value: 30,
-                      message: '할 일 제목은 최대 30글자까지 입력 가능합니다.',
+                      message: '목록 이름은 최대 30글자까지 입력 가능합니다.',
                     },
                     validate: (value: string) => {
                       if (value.trim().length === 0) {
-                        return '할 일 제목에 공백만 입력할 수 없습니다.';
+                        return '목록 이름은 공백만 입력할 수 없습니다.';
                       }
                       return true;
                     },


### PR DESCRIPTION
### 이슈 번호

close #113 

### 변경 사항 요약
#### 할 일 리스트
- [x] 팀 리스트에서 팀 페이지로 이동하는 버튼(로직) 추가
- [x] 팀 페이지의 목록 생성하기 유효성 검사 메시지 통일

#### 할 일 상세
- [x] 할 일 `완료`/`완료 취소하기` 버튼 애니메이션 추가

### 테스트 결과

https://github.com/user-attachments/assets/7e9fa65e-96ba-4e4a-a524-6a0c274d7216

### 리뷰포인트
- 로딩 스피너는 구현 완료 했지만 테스트 영상에서는 아직 미적용 상태입니다.
- Back 버튼은 `이전 페이지`가 아닌 `팀 페이지`로 이동하는 버튼입니다. 따라서 여러 목록으로 이동 후 버튼을 눌러도 팀 페이지로 이동합니다. 