### PR TITLE
로그인 정보 & 접근 권한 로직 충돌 수정

### DIFF
--- a/src/app/(routes)/invitation/page.tsx
+++ b/src/app/(routes)/invitation/page.tsx
@@ -25,7 +25,7 @@ function Page() {
         token,
       });
 
-      queryClient.invalidateQueries({ queryKey: ['group', groupId] });
+      await queryClient.refetchQueries({ queryKey: ['group', groupId] });
       router.push(groupId.toString());
     } catch (error) {
       alert('이미 그룹에 소속된 유저입니다.');

--- a/src/app/hooks/useRedirectIfNotMember.ts
+++ b/src/app/hooks/useRedirectIfNotMember.ts
@@ -12,6 +12,7 @@ const useRedirectIfNotMember = ({
   groupData?: GroupResponse;
 }) => {
   const router = useRouter();
+  const token = useSelector((state: RootState) => state.auth.accessToken);
   const userId = useSelector((state: RootState) => state.auth.user?.id);
   const [isRedirecting, setIsRedirecting] = useState(false);
 
@@ -23,13 +24,14 @@ const useRedirectIfNotMember = ({
 
   useEffect(() => {
     if (
+      token &&
       !isLoading &&
       groupData &&
       !groupData.members.some(({ userId: id }) => id === Number(userId))
     ) {
       redirect();
     }
-  }, [isLoading, groupData, userId, redirect]);
+  }, [token, isLoading, groupData, userId, redirect]);
 
   return { isRedirecting };
 };


### PR DESCRIPTION
### 이슈 번호
#45 

### 변경 사항 요약
- [x] 로그아웃 시 접근 권한 로직 실행되는 이슈  수정
- [x] 팀 참여 로직 실행 후 `접근 제한` 발생하던 이슈 수정

### 테스트 결과
#### 로직 충돌 수정 전
https://github.com/user-attachments/assets/0b22d760-2db4-44e1-9d25-7d52db94e5e1
#### 로직 충돌 수정 후
https://github.com/user-attachments/assets/acb5a2ca-a659-4fc7-af59-767515db00f7
#### 팀 참여 로직 수정 전
https://github.com/user-attachments/assets/16f176fc-043e-477c-b5b8-281d39269124
#### 팀 참여 로직 수정 후

https://github.com/user-attachments/assets/e5f901f2-d4ac-41cb-a5b6-a1957710d3b2




### 리뷰포인트
