### PR TITLE
할 일 리스트/상세 토스트 

### DIFF
--- a/src/app/components/taskdetail/TaskComment.tsx
+++ b/src/app/components/taskdetail/TaskComment.tsx
@@ -18,7 +18,7 @@ function TaskComment({ taskId, setIsModalOpen }: TaskCommentProps) {
 
       {error && (
         <p className="text-text-default">
-          댓글을 불러오는 중 오류가 발생했습니다.
+          댓글을 불러오는 중 오류가 발생했어요.
         </p>
       )}
       <div className="mt-6">

--- a/src/app/components/taskdetail/TaskCommentCard.tsx
+++ b/src/app/components/taskdetail/TaskCommentCard.tsx
@@ -8,6 +8,7 @@ import { useEditTaskCommentMutation } from '@/app/lib/comment/patchComment';
 import Button from '@/app/components/common/button/Button';
 import TaskDetailProfile from '@/app/components/icons/TaskDetailProfile';
 import TaskCommentDropdown from '@/app/components/taskdetail/TaskCommentDropdown';
+import useToast from '@/app/hooks/useToast';
 
 interface TaskCommentItemProps {
   taskId: number;
@@ -20,6 +21,7 @@ function TaskCommentCard({
   comment,
   setIsModalOpen,
 }: TaskCommentItemProps) {
+  const { showToast } = useToast();
   const [isEditing, setIsEditing] = useState(false);
   const [editedComment, setEditedComment] = useState(comment.content);
   const [currentComment, setCurrentComment] = useState(comment.content);
@@ -48,6 +50,10 @@ function TaskCommentCard({
         onSuccess: () => {
           setCurrentComment(editedComment);
           setIsEditing(false);
+          showToast({ message: '댓글 수정 완료!😊', type: 'success' });
+        },
+        onError: () => {
+          showToast({ message: '댓글 수정에 실패했어요.🙁', type: 'error' });
         },
       },
     );

--- a/src/app/components/taskdetail/TaskCommentDropdown.tsx
+++ b/src/app/components/taskdetail/TaskCommentDropdown.tsx
@@ -9,6 +9,7 @@ import DropdownItem from '@/app/components/common/dropdown/DropdownItem';
 import DropdownList from '@/app/components/common/dropdown/DropdownList';
 import DropdownToggle from '@/app/components/common/dropdown/DropdownToggle';
 import DeleteCommentModal from '@/app/components/taskdetail/DeleteCommentModal';
+import useToast from '@/app/hooks/useToast';
 
 interface TaskCommentDropdownProps {
   taskId: number;
@@ -23,6 +24,7 @@ export default function TaskCommentDropdown({
   onEdit,
   setIsModalOpen,
 }: TaskCommentDropdownProps) {
+  const { showToast } = useToast();
   const queryClient = useQueryClient();
   const task = useAppSelector((state) => state.tasks.taskById[taskId]);
   const { mutate: deleteComment, isPending } = useDeleteTaskCommentMutation();
@@ -47,9 +49,10 @@ export default function TaskCommentDropdown({
           });
           closeDropdown();
           setIsDeleteModalOpen(false);
+          showToast({ message: '댓글 삭제 완료!😊', type: 'success' });
         },
         onError: () => {
-          console.error('댓글 삭제 실패');
+          showToast({ message: '댓글 삭제에 실패했어요.🙁', type: 'error' });
         },
       },
     );

--- a/src/app/components/taskdetail/TaskCommentInput.tsx
+++ b/src/app/components/taskdetail/TaskCommentInput.tsx
@@ -3,14 +3,16 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useCreateTaskCommentMutation } from '@/app/lib/comment/postComment';
 import CommentActive from '@/app/components/icons/CommentActive';
 import CommentInactive from '@/app/components/icons/CommentInactive';
+import useToast from '@/app/hooks/useToast';
 
 interface TaskCommentInputProps {
   taskId: number;
 }
 
 function TaskCommentInput({ taskId }: TaskCommentInputProps) {
-  const [comment, setComment] = useState('');
+  const { showToast } = useToast();
   const queryClient = useQueryClient();
+  const [comment, setComment] = useState('');
   const { mutate: createComment, isPending } = useCreateTaskCommentMutation();
 
   const handleSubmit = () => {
@@ -24,6 +26,10 @@ function TaskCommentInput({ taskId }: TaskCommentInputProps) {
           queryClient.invalidateQueries({
             queryKey: ['tasks', taskId, 'comments'],
           });
+          showToast({ message: '댓글 생성 완료!😊', type: 'success' });
+        },
+        onError: () => {
+          showToast({ message: '댓글 생성에 실패했어요.🙁', type: 'error' });
         },
       },
     );

--- a/src/app/components/taskdetail/TaskDetail.tsx
+++ b/src/app/components/taskdetail/TaskDetail.tsx
@@ -79,6 +79,8 @@ function TaskDetail({
   const { name: nameValue, description: descriptionValue } = watch();
 
   const toggleDone = () => {
+    const newDoneState = !doneAt;
+
     editTask(
       {
         groupId,
@@ -86,19 +88,19 @@ function TaskDetail({
         taskId,
         name: nameValue,
         description: descriptionValue,
-        done: !doneAt,
+        done: newDoneState,
       },
       {
         onSuccess: () => {
           queryClient.invalidateQueries({
             queryKey: ['groups', groupId, 'taskLists', taskListId, 'tasks'],
           });
+          if (newDoneState) {
+            showToast({ message: '할 일 완료!🎉', type: 'success' });
+          }
         },
         onError: () => {
-          showToast({
-            message: '할 일 상태 변경에 실패했습니다.',
-            type: 'error',
-          });
+          showToast({ message: '할 일 완료에 실패했어요.🙁', type: 'error' });
         },
       },
     );
@@ -123,9 +125,10 @@ function TaskDetail({
             queryKey: ['groups', groupId, 'taskLists', taskListId, 'tasks'],
           });
           setIsEditing(false);
+          showToast({ message: '할 일 수정 완료!😊', type: 'success' });
         },
         onError: () => {
-          showToast({ message: '할 일 수정에 실패했습니다.' });
+          showToast({ message: '할 일 수정에 실패했어요.🙁', type: 'error' });
         },
       },
     );

--- a/src/app/components/taskdetail/TaskDetailDrawer.tsx
+++ b/src/app/components/taskdetail/TaskDetailDrawer.tsx
@@ -31,15 +31,13 @@ function TaskDetailDrawer({
   const closeDrawer = () => {
     if (isModalOpen) {
       setIsModalOpen(false);
-      setTimeout(() => {
-        setShouldRender(false);
-        onClose();
-      }, 150);
+      setShouldRender(false);
+      onClose();
+
       return;
     }
-
     setShouldRender(false);
-    setTimeout(onClose, 200);
+    onClose();
   };
 
   useClickOutside(drawerRef, () => {
@@ -53,7 +51,6 @@ function TaskDetailDrawer({
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            exit={{ opacity: 0, transition: { duration: 0.3 } }}
             className="fixed inset-0 bg-black/30 transition-opacity"
             onClick={closeDrawer}
           />
@@ -61,10 +58,6 @@ function TaskDetailDrawer({
             ref={drawerRef}
             initial={{ x: '100%' }}
             animate={{ x: 0, transition: { duration: 0.3, ease: 'easeOut' } }}
-            exit={{
-              x: '100%',
-              transition: { duration: 0.3, ease: 'easeInOut' },
-            }}
             className="fixed right-0 top-[3.75rem] z-30 h-full w-[23.4375rem] border border-[rgba(248,250,252,0.1)] bg-background-secondary md:w-[27.1875rem] xl:w-[48.6875rem]"
             onAnimationComplete={() => {
               if (!shouldRender) onClose();

--- a/src/app/components/tasklist/CreateListModal.tsx
+++ b/src/app/components/tasklist/CreateListModal.tsx
@@ -11,6 +11,7 @@ import {
 import Input from '@/app/components/common/input/Input';
 import Modal from '@/app/components/common/modal/Modal';
 import Button from '@/app/components/common/button/Button';
+import useToast from '@/app/hooks/useToast';
 
 interface CreateListModalProps {
   isOpen: boolean;
@@ -23,6 +24,7 @@ export default function CreateListModal({
   onClose,
   groupId,
 }: CreateListModalProps) {
+  const { showToast } = useToast();
   const methods = useForm<PostTaskListRequest>();
   const { setError, reset, handleSubmit } = methods;
   const queryClient = useQueryClient();
@@ -43,13 +45,21 @@ export default function CreateListModal({
             queryKey: ['tasklists', groupId],
           });
           onClose();
+          showToast({ message: '할 일 목록 생성 완료!😊', type: 'success' });
         },
         onError: (error: unknown) => {
-          if (error instanceof AxiosError && error.response?.status === 409) {
-            setError('name', {
-              type: 'manual',
-              message: '그룹 내 이름이 같은 할 일 목록이 존재합니다.',
-            });
+          if (error instanceof AxiosError) {
+            if (error.response?.status === 409) {
+              setError('name', {
+                type: 'manual',
+                message: '그룹 내 이름이 같은 할 일 목록이 존재합니다.',
+              });
+            } else {
+              showToast({
+                message: '할 일 목록 생성에 실패했어요.🙁',
+                type: 'error',
+              });
+            }
           }
         },
       },

--- a/src/app/components/tasklist/CreateTaskModal.tsx
+++ b/src/app/components/tasklist/CreateTaskModal.tsx
@@ -13,6 +13,7 @@ import Input from '@/app/components/common/input/Input';
 import Button from '@/app/components/common/button/Button';
 import RepeatSelector from '@/app/components/tasklist/RepeatSelector';
 import DateTimeSelector from '@/app/components/tasklist/DateTimeSeletor';
+import useToast from '@/app/hooks/useToast';
 
 interface CreateTaskModalProps {
   isOpen: boolean;
@@ -41,6 +42,7 @@ export default function CreateTaskModal({
     },
   });
   const queryClient = useQueryClient();
+  const { showToast } = useToast();
   const { mutate, isPending } = useCreateRecurringTaskMutation();
 
   const { setValue, watch, handleSubmit } = method;
@@ -87,9 +89,10 @@ export default function CreateTaskModal({
           method.reset();
           setSelectedTime('');
           onClose();
+          showToast({ message: '할 일 생성 완료!😊', type: 'success' });
         },
-        onError: (error) => {
-          console.error('에러:', error);
+        onError: () => {
+          showToast({ message: '할 일 생성에 실패했어요.🙁', type: 'error' });
         },
       },
     );

--- a/src/app/components/tasklist/DeleteRecurringModal.tsx
+++ b/src/app/components/tasklist/DeleteRecurringModal.tsx
@@ -2,6 +2,7 @@ import { useAppSelector } from '@/app/stores/hooks';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDeleteRecurringMutation } from '@/app/lib/task/deleteTask';
 import ConfirmModal from '@/app/components/common/modal/ConfirmModal';
+import useToast from '@/app/hooks/useToast';
 
 interface DeleteRecurringModalProps {
   isOpen: boolean;
@@ -19,6 +20,7 @@ export default function DeleteRecurringModal({
   taskListId,
   taskId,
 }: DeleteRecurringModalProps) {
+  const { showToast } = useToast();
   const queryClient = useQueryClient();
   const task = useAppSelector((state) => state.tasks.taskById[taskId]);
   const { mutate, isPending } = useDeleteRecurringMutation();
@@ -36,12 +38,15 @@ export default function DeleteRecurringModal({
           queryClient.invalidateQueries({
             queryKey: ['groups', groupId, 'taskLists', taskListId, 'tasks'],
           });
-
           onClose();
           onDeleteSuccess?.();
+          showToast({ message: '할 일 반복 삭제 완료!😊', type: 'success' });
         },
-        onError: (error) => {
-          console.error('반복 삭제 실패:', error);
+        onError: () => {
+          showToast({
+            message: '할 일 반복 삭제에 실패했어요.🙁',
+            type: 'error',
+          });
         },
       },
     );

--- a/src/app/components/tasklist/DeleteTaskModal.tsx
+++ b/src/app/components/tasklist/DeleteTaskModal.tsx
@@ -2,6 +2,7 @@ import { useAppSelector } from '@/app/stores/hooks';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDeleteTaskMutation } from '@/app/lib/task/deleteTask';
 import ConfirmModal from '@/app/components/common/modal/ConfirmModal';
+import useToast from '@/app/hooks/useToast';
 
 interface DeleteTaskModalProps {
   isOpen: boolean;
@@ -19,6 +20,7 @@ export default function DeleteTaskModal({
   taskListId,
   taskId,
 }: DeleteTaskModalProps) {
+  const { showToast } = useToast();
   const queryClient = useQueryClient();
   const task = useAppSelector((state) => state.tasks.taskById[taskId]);
   const { mutate, isPending } = useDeleteTaskMutation(
@@ -33,12 +35,15 @@ export default function DeleteTaskModal({
         queryClient.invalidateQueries({
           queryKey: ['groups', groupId, 'taskLists', taskListId, 'tasks'],
         });
-
         onClose();
         onDeleteSuccess?.();
+        showToast({ message: '할 일 단일 삭제 완료!😊', type: 'success' });
       },
-      onError: (error) => {
-        console.error('삭제 실패:', error);
+      onError: () => {
+        showToast({
+          message: '할 일 단일 삭제에 실패했어요.🙁',
+          type: 'error',
+        });
       },
     });
   };

--- a/src/app/components/tasklist/EditTaskModal.tsx
+++ b/src/app/components/tasklist/EditTaskModal.tsx
@@ -6,6 +6,7 @@ import { useEditTaskMutation } from '@/app/lib/task/patchTask';
 import Button from '@/app/components/common/button/Button';
 import Input from '@/app/components/common/input/Input';
 import Modal from '@/app/components/common/modal/Modal';
+import useToast from '@/app/hooks/useToast';
 
 interface EditTaskModalProps {
   isOpen: boolean;
@@ -29,6 +30,7 @@ export default function EditTaskModal({
 }: EditTaskModalProps) {
   const queryClient = useQueryClient();
   const task = useAppSelector((state) => state.tasks.taskById[taskId]);
+  const { showToast } = useToast();
 
   const methods = useForm<FormValues>({
     mode: 'onChange',
@@ -56,11 +58,24 @@ export default function EditTaskModal({
               queryKey: ['groups', groupId, 'taskLists', taskListId, 'tasks'],
             });
             onClose();
+            showToast({ message: '할 일 수정 완료!😊', type: 'success' });
+          },
+          onError: () => {
+            showToast({ message: '할 일 수정에 실패했어요.🙁', type: 'error' });
           },
         },
       );
     },
-    [groupId, taskListId, taskId, task, mutate, queryClient, onClose],
+    [
+      groupId,
+      taskListId,
+      taskId,
+      task,
+      mutate,
+      queryClient,
+      showToast,
+      onClose,
+    ],
   );
 
   useEffect(() => {

--- a/src/app/components/tasklist/TaskCard.tsx
+++ b/src/app/components/tasklist/TaskCard.tsx
@@ -55,10 +55,13 @@ export default function TaskCard({
             queryKey: ['groups', groupId, 'taskLists', taskListId, 'tasks'],
           });
           dispatch(updateTask(updatedTask));
+          if (updatedDoneStatus) {
+            showToast({ message: '할 일 완료!🎉', type: 'success' });
+          }
         },
         onError: () => {
           showToast({
-            message: '할 일 상태 변경에 실패했습니다.',
+            message: '할 일 완료에 실패했어요.',
             type: 'error',
           });
         },

--- a/src/app/components/tasklist/TaskCardList.tsx
+++ b/src/app/components/tasklist/TaskCardList.tsx
@@ -48,8 +48,11 @@ function TaskCardList({
   }, [taskListData, dispatch]);
 
   useEffect(() => {
+    document.documentElement.style.overflow = isDrawerOpen ? 'hidden' : '';
     document.body.style.overflow = isDrawerOpen ? 'hidden' : '';
+
     return () => {
+      document.documentElement.style.overflow = '';
       document.body.style.overflow = '';
     };
   }, [isDrawerOpen]);


### PR DESCRIPTION
### 이슈 번호

close #113 

### 변경 사항 요약
- [x] 토스트 추가 및 메시지 통일
- [x] Drawer가 열려있을 때 외부 스크롤 방지 
- [x] Drawer가 닫힐 때 애니메이션 제거

### 테스트 결과
https://github.com/user-attachments/assets/11595a5e-5881-4d68-b5be-1b7c0f1ba4f7


### 리뷰포인트
- 토스트 부분은 해당 브랜치에서 작업했어야 했는데 죄송합니당😢 
- 할 일 완료 토글은 아이콘(🎉)을 달리 넣었습니다(완료 시에만 toast가 보이도록)
- 할 일 삭제 후 drawer가 닫힐 때 에러 메시지가 잠깐 보이는 것이 UI면에서 보기 불편하여 애니메이션을 삭제하였습니다.