### PR TITLE
2차 배포 이슈 해결 & 카카오 로그인 비밀번호 변경 불가 구현

### DIFF
--- a/src/app/components/boarddetail/BoardDetail.tsx
+++ b/src/app/components/boarddetail/BoardDetail.tsx
@@ -156,7 +156,11 @@ export default function BoardDetail({ article }: BoardDetailProps) {
               <Button
                 variant="cancel"
                 size="small"
-                onClick={() => setIsEditing(false)}
+                onClick={() => {
+                  setEditedTitle(article.title);
+                  setEditedContent(article.content);
+                  setIsEditing(false);
+                }}
               >
                 취소
               </Button>

--- a/src/app/components/boarddetail/BoardDetail.tsx
+++ b/src/app/components/boarddetail/BoardDetail.tsx
@@ -10,7 +10,6 @@ import patchArticle, {
 import useArticleActions from '@/app/hooks/useArticleActions';
 import Image from 'next/image';
 import useModal from '@/app/hooks/useModal';
-import IconMore from '@/app/components/icons/IconMore';
 import IconComment from '@/app/components/icons/IconComment';
 
 import Dropdown from '@/app/components/common/dropdown/Dropdown';
@@ -21,6 +20,7 @@ import BoardsLikeBox from '@/app/components/boards/BoardsLikeBox';
 import DeleteArticleModal from '@/app/components/boarddetail/DeleteArticleModal';
 import Button from '@/app/components/common/button/Button';
 import useToast from '@/app/hooks/useToast';
+import TaskCardDropdown from '../icons/TaskCardDropdown';
 
 interface BoardDetailProps {
   article: GetArticleDetailResponse;
@@ -93,7 +93,7 @@ export default function BoardDetail({ article }: BoardDetailProps) {
               className="p-2"
               onClick={() => setIsDropdownOpen((prev) => !prev)}
             >
-              <IconMore />
+              <TaskCardDropdown />
             </DropdownToggle>
             <DropdownList className="right-0 mt-2 w-28" isOpen={isDropdownOpen}>
               <DropdownItem onClick={handleEdit}>수정하기</DropdownItem>

--- a/src/app/components/boarddetail/CommentDropdown.tsx
+++ b/src/app/components/boarddetail/CommentDropdown.tsx
@@ -5,8 +5,8 @@ import DropdownToggle from '@/app/components/common/dropdown/DropdownToggle';
 import DropdownList from '@/app/components/common/dropdown/DropdownList';
 import DropdownItem from '@/app/components/common/dropdown/DropdownItem';
 import useModal from '@/app/hooks/useModal';
-import IconMore from '@/app/components/icons/IconMore';
 import DeleteCommentModal from '@/app/components/boarddetail/DeleteCommentModal';
+import TaskCardDropdown from '../icons/TaskCardDropdown';
 
 interface CommentDropdownProps {
   commentId: number;
@@ -30,7 +30,7 @@ export default function CommentDropdown({
     <>
       <Dropdown className="relative" onClose={closeDropdown}>
         <DropdownToggle className="p-2" onClick={openDropdown}>
-          <IconMore />
+          <TaskCardDropdown />
         </DropdownToggle>
 
         <DropdownList

--- a/src/app/components/boarddetail/CommentDropdown.tsx
+++ b/src/app/components/boarddetail/CommentDropdown.tsx
@@ -57,16 +57,15 @@ export default function CommentDropdown({
       </Dropdown>
 
       {/* 삭제 확인 모달 */}
-      {isModalOpen && (
-        <DeleteCommentModal
-          isOpen={isModalOpen}
-          onClose={closeModal}
-          onConfirm={() => {
-            onDelete(commentId);
-            closeModal();
-          }}
-        />
-      )}
+
+      <DeleteCommentModal
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        onConfirm={() => {
+          onDelete(commentId);
+          closeModal();
+        }}
+      />
     </>
   );
 }

--- a/src/app/components/myhistory/HistoryList.tsx
+++ b/src/app/components/myhistory/HistoryList.tsx
@@ -22,21 +22,13 @@ const groupByDate = (tasks: Task[]) => {
 export default function HistoryList() {
   const { isLoading: isAuthLoading } = useAuthRedirect();
 
-  const { data, error, isLoading } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ['history'],
     queryFn: getHistory,
   });
 
   if (isLoading || isAuthLoading) {
     return <HistoryListSkeleton />;
-  }
-
-  if (error) {
-    return (
-      <p className="text-md font-medium text-red-500">
-        오류 발생: {error instanceof Error ? error.message : '알 수 없는 오류'}
-      </p>
-    );
   }
 
   const history: Task[] = data?.tasksDone || [];
@@ -47,26 +39,31 @@ export default function HistoryList() {
       {Object.entries(groupedHistory).length === 0 ? (
         <p className="text-md font-medium">아직 히스토리가 없습니다.</p>
       ) : (
-        Object.entries(groupedHistory).map(([date, tasks]) => (
-          <div key={date}>
-            <h2 className="mb-4 text-lg font-medium">
-              {date ? formatDate(date) : '날짜 없음'}
-            </h2>
-            <ul>
-              {tasks.map((task) => (
-                <li
-                  className="mb-4 flex items-center rounded-lg bg-background-secondary py-2.5 pl-3.5"
-                  key={task.id}
-                >
-                  <IconCheckBox />
-                  <p className="ml-[0.4375rem] text-md line-through">
-                    {task.name}
-                  </p>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))
+        Object.entries(groupedHistory)
+          .sort(
+            ([dateA], [dateB]) =>
+              new Date(dateB).getTime() - new Date(dateA).getTime(),
+          )
+          .map(([date, tasks]) => (
+            <div key={date}>
+              <h2 className="mb-4 text-lg font-medium">
+                {date ? formatDate(date) : '날짜 없음'}
+              </h2>
+              <ul>
+                {tasks.map((task) => (
+                  <li
+                    className="mb-4 flex items-center rounded-lg bg-background-secondary py-2.5 pl-3.5"
+                    key={task.id}
+                  >
+                    <IconCheckBox />
+                    <p className="ml-[0.4375rem] text-md line-through">
+                      {task.name}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))
       )}
     </div>
   );

--- a/src/app/components/mypage/ResetPassword.tsx
+++ b/src/app/components/mypage/ResetPassword.tsx
@@ -4,7 +4,6 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/app/stores/store';
-import 'react-toastify/dist/ReactToastify.css';
 import useModal from '@/app/hooks/useModal';
 import getUser, { GetUserResponse } from '@/app/lib/user/getUser';
 import { SignInResponse, FormData } from '@/app/types/AuthType';

--- a/src/app/components/mypage/ResetPassword.tsx
+++ b/src/app/components/mypage/ResetPassword.tsx
@@ -2,6 +2,9 @@
 
 import { FormProvider, useForm } from 'react-hook-form';
 import { useQuery, useMutation } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/app/stores/store';
+import 'react-toastify/dist/ReactToastify.css';
 import useModal from '@/app/hooks/useModal';
 import getUser, { GetUserResponse } from '@/app/lib/user/getUser';
 import { SignInResponse, FormData } from '@/app/types/AuthType';
@@ -9,11 +12,16 @@ import postSignInApi from '@/app/lib/auth/postSignInApi';
 import Input from '@/app/components/common/input/Input';
 import Button from '@/app/components/common/button/Button';
 import ResetPasswordModal from '@/app/components/mypage/ResetPasswordModal';
+import useToast from '@/app/hooks/useToast';
 
 export default function ResetPassword() {
   const methods = useForm<FormData>();
   const { handleSubmit, setError } = methods;
   const { isOpen, openModal, closeModal } = useModal();
+  const { showToast } = useToast();
+
+  // 현재 로그인한 OAuth 제공자 확인
+  const provider = useSelector((state: RootState) => state.oauth.provider);
 
   // 유저 데이터 가져오기
   const { data: userData, isLoading } = useQuery<GetUserResponse>({
@@ -44,6 +52,15 @@ export default function ResetPassword() {
   const onSubmit = async (data: FormData) => {
     if (!userData?.email) {
       setError('password', { message: '유저 정보를 불러올 수 없습니다.' });
+      return;
+    }
+
+    // 카카오 로그인 시 비밀번호 변경 불가 처리
+    if (provider === 'KAKAO') {
+      showToast({
+        message: '카카오 로그인 계정은 비밀번호 변경이 불가합니다.🧐',
+        type: 'info',
+      });
       return;
     }
 


### PR DESCRIPTION
### 이슈 번호

close #143 

### 변경 사항 요약

- myhistory 페이지 최근 날짜 순으로 정렬
- 더보기 버튼 TaskCardDropdown으로 변경
- 자유게시판 상세페이지 수정 취소 버그 해결
- 카카오 로그인 시 비밀번호 변경 불가 로직 추가

### 테스트 결과

![image](https://github.com/user-attachments/assets/20bbb74f-cce5-442a-9f5f-173d67e468a0)

### 리뷰포인트
- 비밀번호 변경은 테스트가 불가능해서 테스트를 못하고 코드만 짰는데, 머지 후 배포사이트에서 확인해야할 것 같습니다.
