### PR TITLE
모달 내부 드래그 시 이벤트 버블링 현상 수정

### DIFF
--- a/src/app/components/common/modal/Modal.tsx
+++ b/src/app/components/common/modal/Modal.tsx
@@ -77,9 +77,13 @@ function Modal({
   if (!isOpen && !isAnimating) return null;
 
   return createPortal(
+    // 모달 내부 드래그 시 이벤트 전파를 막기 위해 추가한 이벤트
+    // 이 경우 사용할 수 있는 적절한 역할(role)이 없어 아래 규칙을 비활성화
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div
       className="fixed inset-0 z-50 flex flex-col items-center justify-end transition-opacity tablet:justify-center"
-      onPointerDown={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onTouchStart={(e) => e.stopPropagation()}
     >
       <div ref={modalRef} className="absolute inset-0 bg-black opacity-50" />
       <div


### PR DESCRIPTION
### 이슈 번호

close #113 

### 변경 사항 요약
- 할 일 목록/할 일 카드 내부 드롭다운을 통해 연 모달의 내부를 드래그 하면 배경에 있는 카드가 드래그 되는 버그를 수정하였습니다. 

### 테스트 결과
#### before

https://github.com/user-attachments/assets/a6f12cd8-9bf7-403a-959d-9ed1892217cc

#### after

https://github.com/user-attachments/assets/e09a4c9b-f6a6-4829-b970-19011a1139fb


### 리뷰포인트
- 늦은 시간 PR 죄송합니다😢
- 해당 오류는 이전에 발생하여 해결하였지만, ios/aos 환경에서 dnd 오류를 수정하는 과정에서 로직을 일부 변경하였더니 다시 발생함을 확인했습니다. 
- 수민님이 작업해주신 공통 모달에 변동 사항이 있으나 일전에 말씀드린 부분과 비슷한 역할의 속성으로만 변경하였으니 참고 바랍니다!
- dnd 센서(sensor)를 기존 `PointerSensor`에서 `MouseSensor/TouchSensor`로 분리하였더니, 모달에 적용해두었던 `onPointerDown={(e) => e.stopPropagation()}`가 이를 인식하지 못하는 문제가 있었습니다. 따라서 기존 속성 삭제 후 마우스와 터치를 감지하는 이벤트 핸들러를 추가하였습니다.
- div에 이벤트 핸들러 추가시 발생한 lint에러는 [참고 사이트](https://mystacks.tistory.com/81) 와 [eslint 접근성 규칙 문서](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/93f78856655696a55309440593e0948c6fb96134/docs/rules/no-static-element-interactions.md)를 통하여 해결하였습니다. 규칙 문서 `Case: The event handler is only being used to capture bubbled events` 문단에서 관련 내용을 찾아보실 수 있으니 참고바랍니다!😄 